### PR TITLE
Use yarn workspaces to publish packages

### DIFF
--- a/.changeset/popular-turtles-tap.md
+++ b/.changeset/popular-turtles-tap.md
@@ -1,0 +1,10 @@
+---
+'contexture-client': patch
+'contexture-export': patch
+'contexture-elasticsearch': patch
+'contexture-mongo': patch
+'contexture-react': patch
+'contexture': patch
+---
+
+Republish packages with correct package.json exports field

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,7 +28,7 @@ jobs:
         uses: changesets/action@v1
         with:
           version: yarn version
-          publish: yarn changeset publish
+          publish: yarn publish
         env:
           NPM_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   ],
   "scripts": {
     "foreach": "yarn workspaces foreach --no-private --parallel --verbose",
-    "version": "yarn changeset version && yarn install --mode=update-lockfile"
+    "version": "yarn changeset version && yarn install --mode=update-lockfile",
+    "publish": "yarn foreach npm publish --tolerate-republish"
   },
   "devDependencies": {
     "@changesets/cli": "^2.26.0",


### PR DESCRIPTION
Looks like changesets is not very smart to use yarn when present