### PR TITLE
feat(client): default values for pivot and results nodes

### DIFF
--- a/.changeset/early-cameras-applaud.md
+++ b/.changeset/early-cameras-applaud.md
@@ -1,0 +1,5 @@
+---
+"contexture-client": patch
+---
+
+feat(client): default values for pivot and results nodes

--- a/.changeset/early-cameras-applaud.md
+++ b/.changeset/early-cameras-applaud.md
@@ -1,5 +1,5 @@
 ---
-"contexture-client": patch
+'contexture-client': patch
 ---
 
 feat(client): default values for pivot and results nodes

--- a/packages/client/src/exampleTypes.js
+++ b/packages/client/src/exampleTypes.js
@@ -137,6 +137,7 @@ export default F.stampKey('type', {
     defaults: {
       page: 1,
       pageSize: 10,
+      view: 'table',
       context: {
         results: [],
         totalRecords: null,

--- a/packages/client/src/exampleTypes/pivot.js
+++ b/packages/client/src/exampleTypes/pivot.js
@@ -215,7 +215,18 @@ export default {
     context: {
       results: {},
     },
+    chart: {
+      type: 'Bar',
+      showCounts: false,
+      customTitle: '',
+      colorPalette: 'monochromatic',
+    },
     selectedRows: [],
+    selectedColumns: [],
+    maxSelectedRows: 10,
+    maxSelectedColumns: 10,
+    maxExpandedRows: 10,
+    maxExpandedColumns: 10,
   },
   onDispatch(event, extend) {
     let { type, node, value } = event


### PR DESCRIPTION
* [x] `client`: default values for `pivot` and `results` nodes