### PR TITLE
Fix client group sync

### DIFF
--- a/.changeset/seven-clouds-protect.md
+++ b/.changeset/seven-clouds-protect.md
@@ -2,4 +2,4 @@
 'contexture-client': patch
 ---
 
-Sync computed group fields (markedForUpdate, updating) in cases where runUpdate doesn't run on the whole tree (self updating events with disableAutoUpdate). This fixes the bug introduced with the recent contexture-react change to drive search buttons from root `markedForUpdate` which caused search buttons to stay active indefinitely when dispacthing self-updating changes (like results pageSize and paused mutations)
+Sync computed group fields (markedForUpdate, updating) in cases where runUpdate doesn't run on the whole tree (self-updating events with disableAutoUpdate). This fixes the bug introduced with the recent contexture-react change to drive search buttons from root `markedForUpdate` which caused search buttons to stay active indefinitely when dispatching self-updating changes (like results pageSize and paused mutations)

--- a/.changeset/seven-clouds-protect.md
+++ b/.changeset/seven-clouds-protect.md
@@ -1,0 +1,5 @@
+---
+'contexture-client': patch
+---
+
+Sync computed group fields (markedForUpdate, updating) in cases where runUpdate doesn't run on the whole tree (self updating events with disableAutoUpdate). This fixes the bug introduced with the recent contexture-react change to drive search buttons from root `markedForUpdate` which caused search buttons to stay active indefinitely when dispacthing self-updating changes (like results pageSize and paused mutations)

--- a/packages/client/src/index.js
+++ b/packages/client/src/index.js
@@ -90,6 +90,7 @@ export let ContextTree = _.curry(
       prepForUpdate,
       clearUpdate,
       syncMarkedForUpdate,
+      syncComputedGroupFields,
     } = traversals(extend)
     let typeProp = getTypeProp(types)
 
@@ -156,6 +157,9 @@ export let ContextTree = _.curry(
       markLastUpdate(now)(node || tree)
       let body = serialize(snapshot(tree), types, { search: true })
       prepForUpdate(node || tree)
+      // With disableAutoUpdate, self updating mutations cause runUpdate to be called for just the affected node, so prepForUpdate won't be called on the whole tree
+      // This resets group level fields (and prepForUpdate isn't necessarily safe for the whole tree if other nodes are markedForUpdate but we're only updating one node
+      syncComputedGroupFields(['markedForUpdate', 'updating'], tree)
 
       // make all other nodes filter only
       if (path) {

--- a/packages/client/src/traversals.js
+++ b/packages/client/src/traversals.js
@@ -1,6 +1,6 @@
 import F from 'futil'
 import _ from 'lodash/fp.js'
-import { Tree } from './util/tree.js'
+import { Tree, postWalkBranches } from './util/tree.js'
 
 export default (extend) => {
   let markForUpdate = (x) => {
@@ -40,6 +40,13 @@ export default (extend) => {
       )(tree)
       return updatedNodes
     },
+    syncComputedGroupFields: (fields, tree) =>
+      postWalkBranches((node) =>
+        _.each(
+          (field) => extend(node, { [field]: _.some(field, node.children) }),
+          fields
+        )
+      )(tree),
     markLastUpdate: (time) =>
       Tree.walk((node) => {
         if (node.markedForUpdate) extend(node, { lastUpdateTime: time })

--- a/packages/client/src/util/tree.js
+++ b/packages/client/src/util/tree.js
@@ -19,3 +19,12 @@ export let isParent = _.overEvery([isNotEqual, _.startsWith])
 
 export let pathFromParents = (parents, node) =>
   _.map('key', _.reverse([node, ...parents]))
+
+// Post-order walk tree branches, will be replaced by Tree.walk({ postBranches: fn })
+export let postWalkBranches = (fn) =>
+  Tree.walk(
+    () => {},
+    (node, ...args) => {
+      if (Tree.traverse(node)) fn(node, ...args)
+    }
+  )


### PR DESCRIPTION
Sync computed group fields (markedForUpdate, updating) in cases where runUpdate doesn't run on the whole tree (self-updating events with disableAutoUpdate). This fixes the bug introduced with the recent contexture-react change to drive search buttons from root `markedForUpdate` which caused search buttons to stay active indefinitely when dispatching self-updating changes (like results pageSize and paused mutations)