### PR TITLE
feat(client): `hasResults` prop for result and pivot nodes

### DIFF
--- a/packages/client/src/exampleTypes.js
+++ b/packages/client/src/exampleTypes.js
@@ -126,6 +126,14 @@ export default F.stampKey('type', {
     },
   },
   results: {
+    init(node, extend, snapshot) {
+      if (_.isNil(node.hasResults))
+        Object.defineProperty(node, 'hasResults', {
+          get: () => {
+            return !_.isEmpty(snapshot(node.context.results))
+          },
+        })
+    },
     validate: () => false,
     reactors: {
       page: 'self',

--- a/packages/client/src/exampleTypes/pivot.js
+++ b/packages/client/src/exampleTypes/pivot.js
@@ -113,7 +113,10 @@ export default {
     if (_.isNil(node.hasResults))
       Object.defineProperty(node, 'hasResults', {
         get: () => {
-          let { values, context: { results } } = this
+          let {
+            values,
+            context: { results },
+          } = this
           let noData =
             _.isEmpty(values) ||
             _.flow(
@@ -125,7 +128,7 @@ export default {
       })
 
     extend(node, {
-      expand (tree, type, drilldown) {
+      expand(tree, type, drilldown) {
         drilldown = snapshot(drilldown)
         let n = snapshot(node)
         let path = n.path
@@ -145,7 +148,7 @@ export default {
           ],
         })
       },
-      collapse (tree, type, drilldown) {
+      collapse(tree, type, drilldown) {
         drilldown = snapshot(drilldown)
         let results = _.get('context.results', node)
         let drilldownResults = resultsForDrilldown(type, drilldown, results)
@@ -169,7 +172,7 @@ export default {
         drilldownResults[type] = undefined
         // triggering observer update
         extend(node, { context: { results } })
-      }
+      },
     })
   },
   validate: (context) =>

--- a/packages/client/src/index.js
+++ b/packages/client/src/index.js
@@ -115,7 +115,12 @@ export let ContextTree = _.curry(
       if (event.node)
         // not all dispatches have event.node, e.g. `refresh` with no path
         F.maybeCall(typeProp('onDispatch', event.node), event, extend)
-      await validate(runTypeFunction(types, 'validate'), extend, tree, _.identity)
+      await validate(
+        runTypeFunction(types, 'validate'),
+        extend,
+        tree,
+        _.identity
+      )
       let updatedNodes = [
         // Get updated nodes
         ..._.flatten(bubbleUp(processEvent(event), event.path)),

--- a/packages/client/src/index.js
+++ b/packages/client/src/index.js
@@ -115,7 +115,7 @@ export let ContextTree = _.curry(
       if (event.node)
         // not all dispatches have event.node, e.g. `refresh` with no path
         F.maybeCall(typeProp('onDispatch', event.node), event, extend)
-      await validate(runTypeFunction(types, 'validate'), extend, tree)
+      await validate(runTypeFunction(types, 'validate'), extend, tree, _.identity)
       let updatedNodes = [
         // Get updated nodes
         ..._.flatten(bubbleUp(processEvent(event), event.path)),
@@ -134,7 +134,7 @@ export let ContextTree = _.curry(
           _.map((n) => {
             // When updated by others, force replace instead of merge response
             extend(n, { forceReplaceResponse: true })
-            runTypeFunction(types, 'onUpdateByOthers', n, extend)
+            runTypeFunction(types, 'onUpdateByOthers', n, extend, snapshot)
           }, updatedNodes)
         )
 

--- a/packages/client/src/index.test.js
+++ b/packages/client/src/index.test.js
@@ -2349,7 +2349,7 @@ let AllTests = (ContextureClient) => {
 
     let node = Tree.getNode(['root', 'pivot'])
 
-    node.expand(Tree, ['root', 'pivot'], 'rows', ['Florida'])
+    node.expand(Tree, 'rows', ['Florida'])
 
     // Changing only fields from the skip field list shouldn't reset expansions
     let currentSkipFieldValues = _.pick(skipResetExpansionsFields, node)
@@ -2424,7 +2424,7 @@ let AllTests = (ContextureClient) => {
     })
 
     let node = Tree.getNode(['root', 'pivot'])
-    node.expand(Tree, ['root', 'pivot'], 'rows', ['Florida'])
+    node.expand(Tree, 'rows', ['Florida'])
 
     expect(toJS(Tree.getNode(['root', 'pivot']).expansions)).toEqual([
       { type: 'columns', drilldown: [], loaded: [] },
@@ -2493,8 +2493,8 @@ let AllTests = (ContextureClient) => {
 
     let node = Tree.getNode(['root', 'pivot'])
 
-    node.expand(Tree, ['root', 'pivot'], 'rows', ['NanoSoft'])
-    node.expand(Tree, ['root', 'pivot'], 'columns', ['Florida'])
+    node.expand(Tree, 'rows', ['NanoSoft'])
+    node.expand(Tree, 'columns', ['Florida'])
 
     Tree.mutate(['root', 'pivot'], {
       sort: {

--- a/packages/client/src/node.js
+++ b/packages/client/src/node.js
@@ -38,7 +38,14 @@ export let initNode = _.curry(
     runTypeFunction(types, 'init', node, extend, snapshot)
     let key = dedupe(
       node.key ||
-        runTypeFunctionOrDefault(autoKey, types, 'autoKey', node, extend, snapshot)
+        runTypeFunctionOrDefault(
+          autoKey,
+          types,
+          'autoKey',
+          node,
+          extend,
+          snapshot
+        )
     )
     extend(node, {
       ..._.omit(_.keys(node), defaults),

--- a/packages/client/src/node.js
+++ b/packages/client/src/node.js
@@ -35,10 +35,10 @@ export let autoKey = (x) => F.compactJoin('-', [x.field, x.type]) || 'node'
 
 export let initNode = _.curry(
   ({ extend, types, snapshot }, dedupe, parentPath, node) => {
-    runTypeFunction(types, 'init', node, extend)
+    runTypeFunction(types, 'init', node, extend, snapshot)
     let key = dedupe(
       node.key ||
-        runTypeFunctionOrDefault(autoKey, types, 'autoKey', node, extend)
+        runTypeFunctionOrDefault(autoKey, types, 'autoKey', node, extend, snapshot)
     )
     extend(node, {
       ..._.omit(_.keys(node), defaults),

--- a/packages/client/src/serialize.js
+++ b/packages/client/src/serialize.js
@@ -23,7 +23,14 @@ let mapTree = (fn, tree) =>
 
 export default (tree, types, { search } = {}) => {
   let onSerialize = (node) =>
-    runTypeFunctionOrDefault(_.identity, types, 'onSerialize', node, {}, _.identity)
+    runTypeFunctionOrDefault(
+      _.identity,
+      types,
+      'onSerialize',
+      node,
+      {},
+      _.identity
+    )
 
   let internalKeys = _.without(search && ['lastUpdateTime'], internalStateKeys)
 

--- a/packages/client/src/serialize.js
+++ b/packages/client/src/serialize.js
@@ -23,7 +23,7 @@ let mapTree = (fn, tree) =>
 
 export default (tree, types, { search } = {}) => {
   let onSerialize = (node) =>
-    runTypeFunctionOrDefault(_.identity, types, 'onSerialize', node, {})
+    runTypeFunctionOrDefault(_.identity, types, 'onSerialize', node, {}, _.identity)
 
   let internalKeys = _.without(search && ['lastUpdateTime'], internalStateKeys)
 

--- a/packages/client/src/types.js
+++ b/packages/client/src/types.js
@@ -14,8 +14,8 @@ export let getTypePropOrError = _.curry(
 )
 
 export let runTypeFunctionOrDefault = _.curry(
-  (defaultFn, types, prop, node, extend) =>
-    (getTypeProp(types, prop, node) || defaultFn)(node, extend)
+  (defaultFn, types, prop, node, extend, snapshot) =>
+    (getTypeProp(types, prop, node) || defaultFn)(node, extend, snapshot)
 )
 
 export let runTypeFunction = runTypeFunctionOrDefault(_.stubTrue)


### PR DESCRIPTION
* [x] `results` and `pivot` nodes: `hasResults` prop 
* [x] Refacor: removing `mobx` `toJS` dependency
* [x] Refacor: passing snapshot through `runTypeFunctionOrDefault` to `init` and other node methods 