### PR TITLE
Use `futil`, not `futil-js`, when importing F

### DIFF
--- a/.changeset/funny-eyes-speak.md
+++ b/.changeset/funny-eyes-speak.md
@@ -1,0 +1,5 @@
+---
+'contexture-client': patch
+---
+
+Use `futil`, not `futil-js`, when importing F

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -291,7 +291,7 @@ For those familiar with the previous client implementation (`DataContext`/`Conte
 
 ### Flat Trees
 
-The client maintains a flat tree in addition to the actual tree, which is an object mapped using `flattenTree` from `futil-js`.
+The client maintains a flat tree in addition to the actual tree, which is an object mapped using `flattenTree` from `futil`.
 The keys are the array paths encoded as a string, currently using a slashEncoder.
 This allows path lookups to perform in constant time at `O(1)`, which drastically speeds up some of the internal tree operations.
 The paths are also stamped on individual nodes for convenience as performing an action on a node requires knowing its path.

--- a/packages/client/src/serialize.js
+++ b/packages/client/src/serialize.js
@@ -1,5 +1,5 @@
 import _ from 'lodash/fp.js'
-import F from 'futil-js'
+import F from 'futil'
 import { Tree } from './util/tree.js'
 import { internalStateKeys } from './node.js'
 import { runTypeFunctionOrDefault } from './types.js'


### PR DESCRIPTION
Use `futil`, not `futil-js`, when importing F