### PR TITLE
fix(client/pivot): pivot reset

### DIFF
--- a/.changeset/silver-spies-exist.md
+++ b/.changeset/silver-spies-exist.md
@@ -1,0 +1,5 @@
+---
+'contexture-client': patch
+---
+
+Pivot node: reset pivot results only when pivot config is changed

--- a/packages/client/src/exampleTypes/pivot.js
+++ b/packages/client/src/exampleTypes/pivot.js
@@ -66,11 +66,13 @@ let maybeRemoveSelectedRows = (extend, node) => {
 // Resetting the expansions when the pivot node is changed
 // allows to return expected root results instead of merging result
 // EX: changing the columns or rows config was not returning the new results
-let resetExpansions = (extend, node) => {
+let resetExpansions = (extend, node, clearResults) => {
   extend(node, {
     expansions: [],
-    hasResults: false,
-    context: { results: {} },
+    ...(clearResults && {
+      hasResults: false,
+      context: { results: {} },
+    }),
   })
   // reset selected rows as well, since that is very much dependent on the expansions array
   maybeRemoveSelectedRows(extend, node)
@@ -238,13 +240,13 @@ export default {
     if (_.has('sort', value)) return resetExpandedRows(extend, node)
 
     // if anything else about node configuration is changed resetting expansions
-    resetExpansions(extend, node)
+    resetExpansions(extend, node, true)
   },
   // Resetting the expansions when the tree is changed
   // allows to return expected root results instead of nested drilldown
   // EX: criteria filters didn't work properly when drilldown was applied
   onUpdateByOthers(node, extend) {
-    resetExpansions(extend, node, node)
+    resetExpansions(extend, node)
   },
   shouldMergeResponse: _.flow(
     _.get('expansions'),


### PR DESCRIPTION
* [x] (client) `pivot`: reset pivot results only when pivot config is changed