### PR TITLE
Replace contexture-react outside click handler library

### DIFF
--- a/.changeset/rich-otters-hunt.md
+++ b/.changeset/rich-otters-hunt.md
@@ -1,0 +1,5 @@
+---
+'contexture-react': patch
+---
+
+Replace contexture-react's outside click handler library

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -73,6 +73,7 @@
     "write-pkg": "^4.0.0"
   },
   "dependencies": {
+    "@chakra-ui/react-use-outside-click": "^2.1.0",
     "futil": "^1.74.1",
     "lodash": "^4.17.15",
     "moment": "^2.24.0",
@@ -82,7 +83,6 @@
     "react-dnd": "^2.5.4",
     "react-dnd-html5-backend": "^2.5.4",
     "react-measure": "^2.3.0",
-    "react-outside-click-handler": "^1.2.3",
     "react-recompose": "^0.31.2",
     "reactjs-popup": "^2.0.4"
   },

--- a/packages/react/src/exampleTypes/TagsQuerySearchBar.js
+++ b/packages/react/src/exampleTypes/TagsQuerySearchBar.js
@@ -2,7 +2,7 @@ import React from 'react'
 import F from 'futil'
 import _ from 'lodash/fp.js'
 import { observer } from 'mobx-react'
-import OutsideClickHandler from 'react-outside-click-handler'
+import { useOutsideClick } from '@chakra-ui/react-use-outside-click'
 import { withNode } from '../utils/hoc.js'
 import { Box, ButtonGroup, Button } from '../greyVest/index.js'
 import ExpandableTagsInput, { Tags } from '../greyVest/ExpandableTagsInput.js'
@@ -62,43 +62,39 @@ let SearchBar = ({
   tagsQueryProps,
 }) => {
   let collapse = React.useState(true)
+  let ref = React.useRef()
+  useOutsideClick({ ref, handler: F.on(collapse) })
   return (
-    <OutsideClickHandler.default
-      onOutsideClick={() => {
-        F.on(collapse)()
+    <ButtonGroup
+      ref={ref}
+      data-path={node.path}
+      style={searchBarStyle}
+      // The outside click handler listens for the onMouseUp event which takes priority over any onClick handlers in the children
+      // So we need to add this handler to ensure that the child events are triggered appropriately
+      onMouseUp={(e) => {
+        e.stopPropagation()
       }}
-      useCapture={false}
     >
-      <ButtonGroup
-        data-path={node.path}
-        style={searchBarStyle}
-        // The outside click handler listens for the onMouseUp event which takes priority over any onClick handlers in the children
-        // So we need to add this handler to ensure that the child events are triggered appropriately
-        onMouseUp={(e) => {
-          e.stopPropagation()
-        }}
-      >
-        <Box style={searchBarBoxStyle} onClick={F.off(collapse)}>
-          <ExpandableTagsQuery
-            {...{ tree, node, collapse, actionWrapper }}
-            onAddTag={F.off(collapse)}
-            Loader={({ children }) => <div>{children}</div>}
-            style={inputStyle}
-            theme={{
-              TagsInput:
-                F.view(collapse) && !_.isEmpty(node.tags)
-                  ? Tags
-                  : ExpandableTagsInput,
-            }}
-            autoFocus
-            {...tagsQueryProps}
-          />
-        </Box>
-        {tree.disableAutoUpdate && (
-          <SearchButton tree={tree} searchButtonProps={searchButtonProps} />
-        )}
-      </ButtonGroup>
-    </OutsideClickHandler.default>
+      <Box style={searchBarBoxStyle} onClick={F.off(collapse)}>
+        <ExpandableTagsQuery
+          {...{ tree, node, collapse, actionWrapper }}
+          onAddTag={F.off(collapse)}
+          Loader={({ children }) => <div>{children}</div>}
+          style={inputStyle}
+          theme={{
+            TagsInput:
+              F.view(collapse) && !_.isEmpty(node.tags)
+                ? Tags
+                : ExpandableTagsInput,
+          }}
+          autoFocus
+          {...tagsQueryProps}
+        />
+      </Box>
+      {tree.disableAutoUpdate && (
+        <SearchButton tree={tree} searchButtonProps={searchButtonProps} />
+      )}
+    </ButtonGroup>
   )
 }
 

--- a/packages/react/src/greyVest/ButtonGroup.js
+++ b/packages/react/src/greyVest/ButtonGroup.js
@@ -1,5 +1,6 @@
-import { defaultProps } from 'react-recompose'
+import React from 'react'
 import Flex from './Flex.js'
 
-let ButtonGroup = defaultProps({ className: 'gv-button-group' })(Flex)
-export default ButtonGroup
+export default React.forwardRef((props, ref) => (
+  <Flex ref={ref} className="gv-button-group" {...props} />
+))

--- a/packages/react/src/greyVest/Flex.js
+++ b/packages/react/src/greyVest/Flex.js
@@ -1,28 +1,34 @@
 import React from 'react'
 
-let Flex = ({
-  as: Component = 'div',
-  style,
-  alignItems,
-  alignContent,
-  justifyContent,
-  wrap = false,
-  column = false,
-  inline = false,
-  ...props
-}) => (
-  <Component
-    style={{
-      display: `${inline ? 'inline-' : ''}flex`,
-      flexWrap: wrap && 'wrap',
-      flexDirection: column && 'column',
+let Flex = React.forwardRef(
+  (
+    {
+      as: Component = 'div',
+      style,
       alignItems,
-      justifyContent,
       alignContent,
-      ...style,
-    }}
-    {...props}
-  />
+      justifyContent,
+      wrap = false,
+      column = false,
+      inline = false,
+      ...props
+    },
+    ref
+  ) => (
+    <Component
+      ref={ref}
+      style={{
+        display: `${inline ? 'inline-' : ''}flex`,
+        flexWrap: wrap && 'wrap',
+        flexDirection: column && 'column',
+        alignItems,
+        justifyContent,
+        alignContent,
+        ...style,
+      }}
+      {...props}
+    />
+  )
 )
 
 export default Flex

--- a/yarn.lock
+++ b/yarn.lock
@@ -1607,6 +1607,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@chakra-ui/react-use-callback-ref@npm:2.0.7":
+  version: 2.0.7
+  resolution: "@chakra-ui/react-use-callback-ref@npm:2.0.7"
+  peerDependencies:
+    react: ">=18"
+  checksum: 96c7eb3b62e57cecef724db9c5551e3721ec3d625e540efac3ce087a82a80e9a9e8b5322c51dffd6a2c2c69b989c9a29107239efada077b63208a25732ba6b06
+  languageName: node
+  linkType: hard
+
+"@chakra-ui/react-use-outside-click@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "@chakra-ui/react-use-outside-click@npm:2.1.0"
+  dependencies:
+    "@chakra-ui/react-use-callback-ref": 2.0.7
+  peerDependencies:
+    react: ">=18"
+  checksum: 08106bbbca812cac8ece79a21ede2ad7e953ed252773ae19df73a0d58f32fb3dbc73408ae90a20f4d105ed5a33626005cb9b34bc3c8a86640b6abb8874edc97c
+  languageName: node
+  linkType: hard
+
 "@changesets/apply-release-plan@npm:^6.1.3":
   version: 6.1.3
   resolution: "@changesets/apply-release-plan@npm:6.1.3"
@@ -5027,25 +5047,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"airbnb-prop-types@npm:^2.15.0":
-  version: 2.16.0
-  resolution: "airbnb-prop-types@npm:2.16.0"
-  dependencies:
-    array.prototype.find: ^2.1.1
-    function.prototype.name: ^1.1.2
-    is-regex: ^1.1.0
-    object-is: ^1.1.2
-    object.assign: ^4.1.0
-    object.entries: ^1.1.2
-    prop-types: ^15.7.2
-    prop-types-exact: ^1.2.0
-    react-is: ^16.13.1
-  peerDependencies:
-    react: ^0.14 || ^15.0.0 || ^16.0.0-alpha
-  checksum: 393a5988b99f122c4b935296a6b8c8cbd10345418d67d547cdbcd71d57636cb9abdf9d6556940f70d0b76c3f83448627376557a75b5faf570fb8d262ed4a472f
-  languageName: node
-  linkType: hard
-
 "ajv-formats@npm:^2.1.1":
   version: 2.1.1
   resolution: "ajv-formats@npm:2.1.1"
@@ -5261,18 +5262,6 @@ __metadata:
   version: 2.1.0
   resolution: "array-union@npm:2.1.0"
   checksum: 5bee12395cba82da674931df6d0fea23c4aa4660cb3b338ced9f828782a65caa232573e6bf3968f23e0c5eb301764a382cef2f128b170a9dc59de0e36c39f98d
-  languageName: node
-  linkType: hard
-
-"array.prototype.find@npm:^2.1.1":
-  version: 2.2.1
-  resolution: "array.prototype.find@npm:2.2.1"
-  dependencies:
-    call-bind: ^1.0.2
-    define-properties: ^1.1.4
-    es-abstract: ^1.20.4
-    es-shim-unscopables: ^1.0.0
-  checksum: 3bde6c9137a1b11e28c8e098574ae93aa4c660f3b917ab08e7076ee8ca32704ee158d562437b38b8a5a03b0f0ccacf4df9b7a4e4b4497f4bbe66b8406dc334e5
   languageName: node
   linkType: hard
 
@@ -6415,13 +6404,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"consolidated-events@npm:^1.1.1 || ^2.0.0":
-  version: 2.0.2
-  resolution: "consolidated-events@npm:2.0.2"
-  checksum: 3ffb9fa2647ffbc07845f7ddb22c2e7be88a51aabf2256da860b5e88d9fbbddea60af51d849330d6159fd698881ecd51f168aa07a4f5d238056db75b2e96ff9a
-  languageName: node
-  linkType: hard
-
 "content-disposition@npm:0.5.4":
   version: 0.5.4
   resolution: "content-disposition@npm:0.5.4"
@@ -6520,6 +6502,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "contexture-react@workspace:packages/react"
   dependencies:
+    "@chakra-ui/react-use-outside-click": ^2.1.0
     "@date-io/moment": ^1.3.9
     "@material-ui/core": ^4.3.3
     "@material-ui/pickers": ^3.2.3
@@ -6550,7 +6533,6 @@ __metadata:
     react-dnd-html5-backend: ^2.5.4
     react-dom: ^16.8.0
     react-measure: ^2.3.0
-    react-outside-click-handler: ^1.2.3
     react-recompose: ^0.31.2
     react-select: ^2.0.0
     react-test-renderer: ^16.2.0
@@ -7202,15 +7184,6 @@ __metadata:
   dependencies:
     esutils: ^2.0.2
   checksum: fd7673ca77fe26cd5cba38d816bc72d641f500f1f9b25b83e8ce28827fe2da7ad583a8da26ab6af85f834138cf8dae9f69b0cd6ab925f52ddab1754db44d99ce
-  languageName: node
-  linkType: hard
-
-"document.contains@npm:^1.0.1":
-  version: 1.0.2
-  resolution: "document.contains@npm:1.0.2"
-  dependencies:
-    define-properties: ^1.1.3
-  checksum: dbb8c1f6ec0fa85f9132549ea9fdb11b2b1038171f38f788fbb59f155b02de25236c6ea262bf2052f3811a51e2328180abd206598d00953e502c0dd30e466043
   languageName: node
   linkType: hard
 
@@ -8666,7 +8639,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"function.prototype.name@npm:^1.1.2, function.prototype.name@npm:^1.1.5":
+"function.prototype.name@npm:^1.1.5":
   version: 1.1.5
   resolution: "function.prototype.name@npm:1.1.5"
   dependencies:
@@ -9801,7 +9774,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-regex@npm:^1.1.0, is-regex@npm:^1.1.4":
+"is-regex@npm:^1.1.4":
   version: 1.1.4
   resolution: "is-regex@npm:1.1.4"
   dependencies:
@@ -12021,7 +11994,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"object-is@npm:^1.0.1, object-is@npm:^1.1.2":
+"object-is@npm:^1.0.1":
   version: 1.1.5
   resolution: "object-is@npm:1.1.5"
   dependencies:
@@ -12038,7 +12011,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"object.assign@npm:^4.1.0, object.assign@npm:^4.1.3, object.assign@npm:^4.1.4":
+"object.assign@npm:^4.1.3, object.assign@npm:^4.1.4":
   version: 4.1.4
   resolution: "object.assign@npm:4.1.4"
   dependencies:
@@ -12050,7 +12023,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"object.entries@npm:^1.1.2, object.entries@npm:^1.1.6":
+"object.entries@npm:^1.1.6":
   version: 1.1.6
   resolution: "object.entries@npm:1.1.6"
   dependencies:
@@ -12082,7 +12055,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"object.values@npm:^1.1.0, object.values@npm:^1.1.6":
+"object.values@npm:^1.1.6":
   version: 1.1.6
   resolution: "object.values@npm:1.1.6"
   dependencies:
@@ -12850,17 +12823,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prop-types-exact@npm:^1.2.0":
-  version: 1.2.0
-  resolution: "prop-types-exact@npm:1.2.0"
-  dependencies:
-    has: ^1.0.3
-    object.assign: ^4.1.0
-    reflect.ownkeys: ^0.2.0
-  checksum: 21676a16d5b2623c345ca938554faba7bf29c6ad589eac3f490eda2207bcfd8d25cb3dfda5e5f8e6805239aabd2c6943f7bfbe726a1de708bae2b7a01c03eead
-  languageName: node
-  linkType: hard
-
 "prop-types@npm:^15.5.10, prop-types@npm:^15.5.8, prop-types@npm:^15.6.0, prop-types@npm:^15.6.1, prop-types@npm:^15.6.2, prop-types@npm:^15.7.2, prop-types@npm:^15.8.1":
   version: 15.8.1
   resolution: "prop-types@npm:15.8.1"
@@ -13265,22 +13227,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-outside-click-handler@npm:^1.2.3":
-  version: 1.3.0
-  resolution: "react-outside-click-handler@npm:1.3.0"
-  dependencies:
-    airbnb-prop-types: ^2.15.0
-    consolidated-events: ^1.1.1 || ^2.0.0
-    document.contains: ^1.0.1
-    object.values: ^1.1.0
-    prop-types: ^15.7.2
-  peerDependencies:
-    react: ^0.14 || >=15
-    react-dom: ^0.14 || >=15
-  checksum: c3afc3ce1c1d4c2df8d650ae399848dd788c6e41798ef0cd9701b2279c41bfd52b4cbac428a942995444ef2fffcc9126351a7de9f05e1c42fbe2a9454a2ec250
-  languageName: node
-  linkType: hard
-
 "react-recompose@npm:^0.31.2":
   version: 0.31.2
   resolution: "react-recompose@npm:0.31.2"
@@ -13531,13 +13477,6 @@ __metadata:
     loose-envify: ^1.1.0
     symbol-observable: ^1.0.3
   checksum: c349b77e68d009bc530d3cb6252a6a3e43e20a6e52f9483a048b24cd2f266d9bfa6f0bbd4769d40fe36795e2f7a7a884c3ddc92c13e82efd3328890f94821091
-  languageName: node
-  linkType: hard
-
-"reflect.ownkeys@npm:^0.2.0":
-  version: 0.2.0
-  resolution: "reflect.ownkeys@npm:0.2.0"
-  checksum: 9530b166569e547c2cf25ade3cdc39c662212feeccf3e0ed46e6d8abf92f5683c82d7857011cee6230bf648eb0b99b6b419a007012b8571dcd4bb4d818d3b88d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
The current `react-outside-click-handler` library is 4 years old and it's not packaged right so it doesn't work in storybook. This PR replaces it with chakra's equivalent library, which uses a hook instead.