### PR TITLE
feat(client): runTypeFunction actions

### DIFF
--- a/.changeset/orange-starfishes-roll.md
+++ b/.changeset/orange-starfishes-roll.md
@@ -1,0 +1,5 @@
+---
+'contexture-client': minor
+---
+
+Passing actions to the runTypeFunction. Removing bundled mobx dependency

--- a/packages/client/src/exampleTypes.js
+++ b/packages/client/src/exampleTypes.js
@@ -143,11 +143,11 @@ export default F.stampKey('type', {
         totalRecords: null,
       },
     },
-    onUpdateByOthers(node, extend) {
+    onUpdateByOthers(node, {extend}) {
       extend(node, { page: 1 })
     },
     shouldMergeResponse: (node) => node.infiniteScroll,
-    mergeResponse(node, response, extend) {
+    mergeResponse(node, response, {extend}) {
       // extend but merge results arrays
       extend(node, {
         context: {

--- a/packages/client/src/exampleTypes.js
+++ b/packages/client/src/exampleTypes.js
@@ -143,11 +143,11 @@ export default F.stampKey('type', {
         totalRecords: null,
       },
     },
-    onUpdateByOthers(node, {extend}) {
+    onUpdateByOthers(node, { extend }) {
       extend(node, { page: 1 })
     },
     shouldMergeResponse: (node) => node.infiniteScroll,
-    mergeResponse(node, response, {extend}) {
+    mergeResponse(node, response, { extend }) {
       // extend but merge results arrays
       extend(node, {
         context: {

--- a/packages/client/src/exampleTypes/pivot.js
+++ b/packages/client/src/exampleTypes/pivot.js
@@ -113,9 +113,9 @@ export let skipResetExpansionsFields = [
 ]
 
 export default {
-  init: (node, {extend, snapshot}) => {
+  init: (node, { extend, snapshot }) => {
     extend(node, {
-      expand(tree, type, drilldown)  {
+      expand(tree, type, drilldown) {
         drilldown = snapshot(drilldown)
         let n = snapshot(node)
         let path = n.path
@@ -159,7 +159,7 @@ export default {
         drilldownResults[type] = undefined
         // triggering observer update
         extend(node, { context: { results } })
-      }
+      },
     })
   },
   validate: (node) =>
@@ -223,7 +223,7 @@ export default {
     selectedRows: [],
     selectedColumns: [],
   },
-  onDispatch(event, {extend}) {
+  onDispatch(event, { extend }) {
     let { type, node, value } = event
     if (type !== 'mutate') return
     // if no other fields are changing, do not proceed (but also continue in case there are other properties being mutated)
@@ -240,7 +240,7 @@ export default {
   // Resetting the expansions when the tree is changed
   // allows to return expected root results instead of nested drilldown
   // EX: criteria filters didn't work properly when drilldown was applied
-  onUpdateByOthers(node, {extend}) {
+  onUpdateByOthers(node, { extend }) {
     resetExpansions(node, extend, false)
   },
   shouldMergeResponse: _.flow(
@@ -248,7 +248,7 @@ export default {
     _.filter({ type: 'rows' }),
     _.negate(_.isEmpty)
   ),
-  mergeResponse(node, response, {extend, snapshot}) {
+  mergeResponse(node, response, { extend, snapshot }) {
     let findNotLoadedExpansion = () =>
       _.find(({ loaded }) => !loaded, node.expansions)
 

--- a/packages/client/src/exampleTypes/pivot.js
+++ b/packages/client/src/exampleTypes/pivot.js
@@ -119,14 +119,13 @@ export default {
         drilldown = snapshot(drilldown)
         let n = snapshot(node)
         let path = n.path
-        let expansions = n.expansions
 
         maybeAddRootExpansion(n, 'columns')
         maybeAddRootExpansion(n, 'rows')
 
         tree.mutate(path, {
           expansions: [
-            ...expansions,
+            ...n.expansions,
             {
               type,
               drilldown,

--- a/packages/client/src/exampleTypes/pivot.js
+++ b/packages/client/src/exampleTypes/pivot.js
@@ -1,6 +1,5 @@
 import _ from 'lodash/fp.js'
 import F from 'futil'
-import { toJS } from 'mobx'
 
 let getKey = (x) => x.keyAsString || x.key
 
@@ -16,9 +15,7 @@ let resultsForDrilldown = (type, drilldown, results) => {
 }
 
 let previouslyLoadedKeys = (expansion, expansions) => {
-  expansion = toJS(expansion)
   return _.flow(
-    toJS,
     _.filter(
       ({ type, drilldown, loaded }) =>
         type === expansion.type &&
@@ -51,9 +48,9 @@ let mergeResults = _.mergeWith((current, additional, prop) => {
   } else if (_.isArray(additional)) return additional
 })
 
-let maybeRemoveSelectedRows = (extend, node) => {
+let maybeRemoveSelectedRows = (node, extend) => {
   let selectedRows = _.filter((rowPath) => {
-    let expansion = { type: 'rows', drilldown: _.initial(toJS(rowPath)) }
+    let expansion = { type: 'rows', drilldown: _.initial(rowPath) }
     let parentRowLoadedKeys = previouslyLoadedKeys(expansion, node.expansions)
     return (
       _.isEmpty(rowPath) || _.includes(_.last(rowPath), parentRowLoadedKeys)
@@ -66,7 +63,7 @@ let maybeRemoveSelectedRows = (extend, node) => {
 // Resetting the expansions when the pivot node is changed
 // allows to return expected root results instead of merging result
 // EX: changing the columns or rows config was not returning the new results
-let resetExpansions = (extend, node, clearResults) => {
+let resetExpansions = (node, extend, clearResults) => {
   extend(node, {
     expansions: [],
     ...(clearResults && {
@@ -75,11 +72,11 @@ let resetExpansions = (extend, node, clearResults) => {
     }),
   })
   // reset selected rows as well, since that is very much dependent on the expansions array
-  maybeRemoveSelectedRows(extend, node)
+  maybeRemoveSelectedRows(node, extend)
 }
 
 // Resetting the row expansions and columns loaded when the sorting is changed
-let resetExpandedRows = (extend, node) => {
+let resetExpandedRows = (node, extend) => {
   extend(node, {
     expansions: _.flow(
       _.filter({ type: 'columns' }),
@@ -87,7 +84,7 @@ let resetExpandedRows = (extend, node) => {
     )(node.expansions),
   })
   // reset selected rows as well, since that is very much dependent on the expansions array
-  maybeRemoveSelectedRows(extend, node)
+  maybeRemoveSelectedRows(node, extend)
 }
 
 // adding values for initial root level expansions
@@ -107,55 +104,6 @@ let maybeAddRootExpansion = (node, type) => {
   }
 }
 
-let expand = (tree, path, type, drilldown) => {
-  path = toJS(path)
-  drilldown = toJS(drilldown)
-  let node = toJS(tree.getNode(path))
-  let expansions = node.expansions
-
-  maybeAddRootExpansion(node, 'columns')
-  maybeAddRootExpansion(node, 'rows')
-
-  tree.mutate(path, {
-    expansions: [
-      ...expansions,
-      {
-        type,
-        drilldown,
-        loaded: false,
-      },
-    ],
-  })
-}
-
-let collapse = (tree, path, type, drilldown) => {
-  path = toJS(path)
-  drilldown = toJS(drilldown)
-  let node = tree.getNode(path)
-  let results = toJS(_.get('context.results', node))
-  let drilldownResults = resultsForDrilldown(type, drilldown, results)
-
-  // removing expansions under this drilldown level
-  node.expansions = _.filter(
-    (expansion) =>
-      expansion.type !== type ||
-      !_.isEqual(
-        // expantion.drilldown is not a child of drilldown
-        _.take(drilldown.length, expansion.drilldown),
-        _.toArray(drilldown)
-      )
-  )(node.expansions)
-
-  if (type === 'rows') {
-    maybeRemoveSelectedRows(tree.extend, node)
-  }
-
-  // removing collapsed rows or columns from results
-  drilldownResults[type] = undefined
-  // triggering observer update
-  tree.extend(node, { context: { results } })
-}
-
 export let skipResetExpansionsFields = [
   'paused',
   'expansions',
@@ -165,6 +113,55 @@ export let skipResetExpansionsFields = [
 ]
 
 export default {
+  init: (node, {extend, snapshot}) => {
+    extend(node, {
+      expand(tree, type, drilldown)  {
+        drilldown = snapshot(drilldown)
+        let n = snapshot(node)
+        let path = n.path
+        let expansions = n.expansions
+
+        maybeAddRootExpansion(n, 'columns')
+        maybeAddRootExpansion(n, 'rows')
+
+        tree.mutate(path, {
+          expansions: [
+            ...expansions,
+            {
+              type,
+              drilldown,
+              loaded: false,
+            },
+          ],
+        })
+      },
+      collapse(tree, type, drilldown) {
+        drilldown = snapshot(drilldown)
+        let results = _.get('context.results', node)
+        let drilldownResults = resultsForDrilldown(type, drilldown, results)
+
+        // removing expansions under this drilldown level
+        node.expansions = _.filter(
+          (expansion) =>
+            expansion.type !== type ||
+            !_.isEqual(
+              // expantion.drilldown is not a child of drilldown
+              _.take(drilldown.length, expansion.drilldown),
+              _.toArray(drilldown)
+            )
+        )(node.expansions)
+
+        if (type === 'rows') {
+          maybeRemoveSelectedRows(node, extend)
+        }
+
+        // removing collapsed rows or columns from results
+        drilldownResults[type] = undefined
+        // triggering observer update
+        extend(node, { context: { results } })
+      }
+    })
+  },
   validate: (node) =>
     _.every(
       ({ type, ranges, percents }) =>
@@ -193,8 +190,6 @@ export default {
       columns: false,
       rows: false,
     },
-    expand,
-    collapse,
     expansions: [
       /*
      {
@@ -228,7 +223,7 @@ export default {
     selectedRows: [],
     selectedColumns: [],
   },
-  onDispatch(event, extend) {
+  onDispatch(event, {extend}) {
     let { type, node, value } = event
     if (type !== 'mutate') return
     // if no other fields are changing, do not proceed (but also continue in case there are other properties being mutated)
@@ -237,23 +232,23 @@ export default {
     }
 
     // if sorting is changed we are preserving expanded columns
-    if (_.has('sort', value)) return resetExpandedRows(extend, node)
+    if (_.has('sort', value)) return resetExpandedRows(node, extend)
 
     // if anything else about node configuration is changed resetting expansions
-    resetExpansions(extend, node, true)
+    resetExpansions(node, extend, true)
   },
   // Resetting the expansions when the tree is changed
   // allows to return expected root results instead of nested drilldown
   // EX: criteria filters didn't work properly when drilldown was applied
-  onUpdateByOthers(node, extend) {
-    resetExpansions(extend, node)
+  onUpdateByOthers(node, {extend}) {
+    resetExpansions(node, extend, false)
   },
   shouldMergeResponse: _.flow(
     _.get('expansions'),
     _.filter({ type: 'rows' }),
     _.negate(_.isEmpty)
   ),
-  mergeResponse(node, response, extend, snapshot) {
+  mergeResponse(node, response, {extend, snapshot}) {
     let findNotLoadedExpansion = () =>
       _.find(({ loaded }) => !loaded, node.expansions)
 
@@ -271,6 +266,6 @@ export default {
     // Write on the node
     extend(node, { context })
     // remove selected rows that are no longer part of the result
-    maybeRemoveSelectedRows(extend, node)
+    maybeRemoveSelectedRows(node, extend)
   },
 }

--- a/packages/client/src/index.js
+++ b/packages/client/src/index.js
@@ -121,8 +121,17 @@ export let ContextTree = _.curry(
       if (debug) debugInfo.dispatchHistory.push(event)
       if (event.node)
         // not all dispatches have event.node, e.g. `refresh` with no path
-        F.maybeCall(typeProp('onDispatch', event.node), event, {extend, snapshot, initObject, log})
-      await validate(runTypeFunction(types, 'validate'), {extend, snapshot, initObject, log}, tree)
+        F.maybeCall(typeProp('onDispatch', event.node), event, {
+          extend,
+          snapshot,
+          initObject,
+          log,
+        })
+      await validate(
+        runTypeFunction(types, 'validate'),
+        { extend, snapshot, initObject, log },
+        tree
+      )
       let updatedNodes = [
         // Get updated nodes
         ..._.flatten(bubbleUp(processEvent(event), event.path)),
@@ -141,7 +150,12 @@ export let ContextTree = _.curry(
           _.map((n) => {
             // When updated by others, force replace instead of merge response
             extend(n, { forceReplaceResponse: true })
-            runTypeFunction(types, 'onUpdateByOthers', n, {extend, snapshot, initObject, log})
+            runTypeFunction(types, 'onUpdateByOthers', n, {
+              extend,
+              snapshot,
+              initObject,
+              log,
+            })
           }, updatedNodes)
         )
 
@@ -227,12 +241,10 @@ export let ContextTree = _.curry(
             !target.forceReplaceResponse &&
             F.maybeCall(typeProp('shouldMergeResponse', target), target)
           )
-            typeProp('mergeResponse', target)(
-              target,
-              responseNode,
-              {extend,
-              snapshot}
-            )
+            typeProp('mergeResponse', target)(target, responseNode, {
+              extend,
+              snapshot,
+            })
           else {
             target.forceReplaceResponse = false
             extend(target, responseNode)

--- a/packages/client/src/index.js
+++ b/packages/client/src/index.js
@@ -122,11 +122,7 @@ export let ContextTree = _.curry(
       if (event.node)
         // not all dispatches have event.node, e.g. `refresh` with no path
         F.maybeCall(typeProp('onDispatch', event.node), event, actionProps)
-      await validate(
-        runTypeFunction(types, 'validate'),
-        actionProps,
-        tree
-      )
+      await validate(runTypeFunction(types, 'validate'), actionProps, tree)
       let updatedNodes = [
         // Get updated nodes
         ..._.flatten(bubbleUp(processEvent(event), event.path)),

--- a/packages/client/src/index.test.js
+++ b/packages/client/src/index.test.js
@@ -574,7 +574,7 @@ let AllTests = (ContextureClient) => {
     expect(filterUpdated).toBeCalledTimes(1)
   })
   it('should support custom type initializers', async () => {
-    let testInit = jest.fn((node, extend) => extend(node, { isExtended: true }))
+    let testInit = jest.fn((node,{ extend}) => extend(node, { isExtended: true }))
     let Tree = ContextureClient(
       {
         debounce: 1,
@@ -1406,7 +1406,7 @@ let AllTests = (ContextureClient) => {
         },
       },
       results: {
-        onUpdateByOthers(node, extend) {
+        onUpdateByOthers(node, {extend}) {
           extend(node, { page: 1 })
         },
       },
@@ -2126,8 +2126,7 @@ let AllTests = (ContextureClient) => {
       exampleTypes.pivot.mergeResponse(
         node,
         { context: { results } },
-        Tree.extend,
-        Tree.snapshot
+        Tree
       )
     merge({
       rows: [
@@ -2186,8 +2185,7 @@ let AllTests = (ContextureClient) => {
       exampleTypes.pivot.mergeResponse(
         node,
         { context: { results } },
-        Tree.extend,
-        Tree.snapshot
+        Tree,
       )
     merge({
       rows: [
@@ -2367,7 +2365,7 @@ let AllTests = (ContextureClient) => {
 
     let node = Tree.getNode(['root', 'pivot'])
 
-    node.expand(Tree, ['root', 'pivot'], 'rows', ['Florida'])
+    node.expand(Tree, 'rows', ['Florida'])
 
     // Changing only fields from the skip field list shouldn't reset expansions
     let currentSkipFieldValues = _.pick(skipResetExpansionsFields, node)
@@ -2443,7 +2441,7 @@ let AllTests = (ContextureClient) => {
     })
 
     let node = Tree.getNode(['root', 'pivot'])
-    node.expand(Tree, ['root', 'pivot'], 'rows', ['Florida'])
+    node.expand(Tree, 'rows', ['Florida'])
 
     expect(toJS(Tree.getNode(['root', 'pivot']).expansions)).toEqual([
       { type: 'columns', drilldown: [], loaded: [] },
@@ -2508,8 +2506,8 @@ let AllTests = (ContextureClient) => {
 
     let node = Tree.getNode(['root', 'pivot'])
 
-    node.expand(Tree, ['root', 'pivot'], 'rows', ['NanoSoft'])
-    node.expand(Tree, ['root', 'pivot'], 'columns', ['Florida'])
+    node.expand(Tree, 'rows', ['NanoSoft'])
+    node.expand(Tree, 'columns', ['Florida'])
 
     Tree.mutate(['root', 'pivot'], {
       sort: {

--- a/packages/client/src/index.test.js
+++ b/packages/client/src/index.test.js
@@ -574,7 +574,9 @@ let AllTests = (ContextureClient) => {
     expect(filterUpdated).toBeCalledTimes(1)
   })
   it('should support custom type initializers', async () => {
-    let testInit = jest.fn((node,{ extend}) => extend(node, { isExtended: true }))
+    let testInit = jest.fn((node, { extend }) =>
+      extend(node, { isExtended: true })
+    )
     let Tree = ContextureClient(
       {
         debounce: 1,
@@ -1406,7 +1408,7 @@ let AllTests = (ContextureClient) => {
         },
       },
       results: {
-        onUpdateByOthers(node, {extend}) {
+        onUpdateByOthers(node, { extend }) {
           extend(node, { page: 1 })
         },
       },
@@ -2123,11 +2125,7 @@ let AllTests = (ContextureClient) => {
 
     // TODO test the loaded field population
     let merge = (results) =>
-      exampleTypes.pivot.mergeResponse(
-        node,
-        { context: { results } },
-        Tree
-      )
+      exampleTypes.pivot.mergeResponse(node, { context: { results } }, Tree)
     merge({
       rows: [
         { key: 'FL', rows: [{ key: 'fl1', a: 1 }] },
@@ -2182,11 +2180,7 @@ let AllTests = (ContextureClient) => {
 
     // TODO test the loaded field population
     let merge = (results) =>
-      exampleTypes.pivot.mergeResponse(
-        node,
-        { context: { results } },
-        Tree,
-      )
+      exampleTypes.pivot.mergeResponse(node, { context: { results } }, Tree)
     merge({
       rows: [
         {

--- a/packages/client/src/node.js
+++ b/packages/client/src/node.js
@@ -30,16 +30,21 @@ export let internalStateKeys = [
   'onMarkForUpdate',
   'afterSearch',
   'forceReplaceResponse',
+  'expand',
+  'collapse',
 ]
 
 export let autoKey = (x) => F.compactJoin('-', [x.field, x.type]) || 'node'
 
 export let initNode = _.curry(
-  ({ extend, types, snapshot }, dedupe, parentPath, node) => {
-    runTypeFunction(types, 'init', node, extend)
+  (actions, dedupe, parentPath, node) => {
+    const { extend, types, snapshot } = actions
+    actions = _.omit(['types'], actions)
+
+    runTypeFunction(types, 'init', node, actions)
     let key = dedupe(
       node.key ||
-        runTypeFunctionOrDefault(autoKey, types, 'autoKey', node, extend)
+        runTypeFunctionOrDefault(autoKey, types, 'autoKey', node, actions)
     )
     extend(node, {
       ..._.omit(_.keys(node), defaults),

--- a/packages/client/src/node.js
+++ b/packages/client/src/node.js
@@ -36,14 +36,14 @@ export let internalStateKeys = [
 
 export let autoKey = (x) => F.compactJoin('-', [x.field, x.type]) || 'node'
 
-export let initNode = _.curry((actions, dedupe, parentPath, node) => {
-  const { extend, types, snapshot } = actions
-  actions = _.omit(['types'], actions)
+export let initNode = _.curry((props, dedupe, parentPath, node) => {
+  let { types, extend, snapshot } = props
+  let actionProps = _.omit(['types'], props)
 
-  runTypeFunction(types, 'init', node, actions)
+  runTypeFunction(types, 'init', node, actionProps)
   let key = dedupe(
     node.key ||
-      runTypeFunctionOrDefault(autoKey, types, 'autoKey', node, actions)
+      runTypeFunctionOrDefault(autoKey, types, 'autoKey', node, actionProps)
   )
   extend(node, {
     ..._.omit(_.keys(node), defaults),

--- a/packages/client/src/node.js
+++ b/packages/client/src/node.js
@@ -36,25 +36,23 @@ export let internalStateKeys = [
 
 export let autoKey = (x) => F.compactJoin('-', [x.field, x.type]) || 'node'
 
-export let initNode = _.curry(
-  (actions, dedupe, parentPath, node) => {
-    const { extend, types, snapshot } = actions
-    actions = _.omit(['types'], actions)
+export let initNode = _.curry((actions, dedupe, parentPath, node) => {
+  const { extend, types, snapshot } = actions
+  actions = _.omit(['types'], actions)
 
-    runTypeFunction(types, 'init', node, actions)
-    let key = dedupe(
-      node.key ||
-        runTypeFunctionOrDefault(autoKey, types, 'autoKey', node, actions)
-    )
-    extend(node, {
-      ..._.omit(_.keys(node), defaults),
-      // For some reason, type defaults can end up observable in real world apps, so we `snapshot` instead of `_.deepClone`
-      ..._.omit(_.keys(node), snapshot(getTypeProp(types, 'defaults', node))),
-      key,
-      path: [...parentPath, key],
-    })
-  }
-)
+  runTypeFunction(types, 'init', node, actions)
+  let key = dedupe(
+    node.key ||
+      runTypeFunctionOrDefault(autoKey, types, 'autoKey', node, actions)
+  )
+  extend(node, {
+    ..._.omit(_.keys(node), defaults),
+    // For some reason, type defaults can end up observable in real world apps, so we `snapshot` instead of `_.deepClone`
+    ..._.omit(_.keys(node), snapshot(getTypeProp(types, 'defaults', node))),
+    key,
+    path: [...parentPath, key],
+  })
+})
 
 // fn: (dedupe: string -> string, parentPath: array, node: object) -> void
 export let dedupeWalk = (fn, tree, { target = {}, dedupe } = {}) => {

--- a/packages/client/src/node.js
+++ b/packages/client/src/node.js
@@ -36,9 +36,8 @@ export let internalStateKeys = [
 
 export let autoKey = (x) => F.compactJoin('-', [x.field, x.type]) || 'node'
 
-export let initNode = _.curry((props, dedupe, parentPath, node) => {
-  let { types, extend, snapshot } = props
-  let actionProps = _.omit(['types'], props)
+export let initNode = _.curry((actionProps, dedupe, parentPath, node) => {
+  let { types, extend, snapshot } = actionProps
 
   runTypeFunction(types, 'init', node, actionProps)
   let key = dedupe(

--- a/packages/client/src/serialize.js
+++ b/packages/client/src/serialize.js
@@ -23,8 +23,12 @@ let mapTree = (fn, tree) =>
 
 export default (tree, types, { search } = {}) => {
   let onSerialize = (node) =>
-    runTypeFunctionOrDefault(_.identity, types, 'onSerialize', node, { extend: _.identity, snapshot: _.identity,
-      initObject: _.identity, log: _.identity })
+    runTypeFunctionOrDefault(_.identity, types, 'onSerialize', node, {
+      extend: _.identity,
+      snapshot: _.identity,
+      initObject: _.identity,
+      log: _.identity,
+    })
 
   let internalKeys = _.without(search && ['lastUpdateTime'], internalStateKeys)
 

--- a/packages/client/src/serialize.js
+++ b/packages/client/src/serialize.js
@@ -23,12 +23,7 @@ let mapTree = (fn, tree) =>
 
 export default (tree, types, { search } = {}) => {
   let onSerialize = (node) =>
-    runTypeFunctionOrDefault(_.identity, types, 'onSerialize', node, {
-      extend: _.identity,
-      snapshot: _.identity,
-      initObject: _.identity,
-      log: _.identity,
-    })
+    runTypeFunctionOrDefault(_.identity, types, 'onSerialize', node, {})
 
   let internalKeys = _.without(search && ['lastUpdateTime'], internalStateKeys)
 

--- a/packages/client/src/serialize.js
+++ b/packages/client/src/serialize.js
@@ -23,7 +23,8 @@ let mapTree = (fn, tree) =>
 
 export default (tree, types, { search } = {}) => {
   let onSerialize = (node) =>
-    runTypeFunctionOrDefault(_.identity, types, 'onSerialize', node, {})
+    runTypeFunctionOrDefault(_.identity, types, 'onSerialize', node, { extend: _.identity, snapshot: _.identity,
+      initObject: _.identity, log: _.identity })
 
   let internalKeys = _.without(search && ['lastUpdateTime'], internalStateKeys)
 

--- a/packages/client/src/types.js
+++ b/packages/client/src/types.js
@@ -14,8 +14,8 @@ export let getTypePropOrError = _.curry(
 )
 
 export let runTypeFunctionOrDefault = _.curry(
-  (defaultFn, types, prop, node, extend) =>
-    (getTypeProp(types, prop, node) || defaultFn)(node, extend)
+  (defaultFn, types, prop, node, actions) =>
+    (getTypeProp(types, prop, node) || defaultFn)(node, actions)
 )
 
 export let runTypeFunction = runTypeFunctionOrDefault(_.stubTrue)

--- a/packages/client/src/validation.js
+++ b/packages/client/src/validation.js
@@ -3,15 +3,15 @@ import F from 'futil'
 
 // Aync fn to inspect types.
 // ASYNC runValidate: return true -> proceed, return false -> exclude, throw -> error!
-export let validate = _.curry(async (runValidate, actions, child) => {
-  let { extend } = actions
+export let validate = _.curry(async (runValidate, actionProps, child) => {
+  let { extend } = actionProps
   extend(child, { error: null })
   try {
     if (child.children)
-      await F.flowAsync(_.map)(validate(runValidate, actions), child.children)
+      await F.flowAsync(_.map)(validate(runValidate, actionProps), child.children)
     let hasValue = child.children
       ? _.some('hasValue', child.children)
-      : await runValidate(child, actions)
+      : await runValidate(child, actionProps)
     extend(child, { hasValue })
     return hasValue
   } catch (error) {

--- a/packages/client/src/validation.js
+++ b/packages/client/src/validation.js
@@ -8,7 +8,10 @@ export let validate = _.curry(async (runValidate, actionProps, child) => {
   extend(child, { error: null })
   try {
     if (child.children)
-      await F.flowAsync(_.map)(validate(runValidate, actionProps), child.children)
+      await F.flowAsync(_.map)(
+        validate(runValidate, actionProps),
+        child.children
+      )
     let hasValue = child.children
       ? _.some('hasValue', child.children)
       : await runValidate(child, actionProps)

--- a/packages/client/src/validation.js
+++ b/packages/client/src/validation.js
@@ -4,7 +4,7 @@ import F from 'futil'
 // Aync fn to inspect types.
 // ASYNC runValidate: return true -> proceed, return false -> exclude, throw -> error!
 export let validate = _.curry(async (runValidate, actions, child) => {
-  let {extend} = actions
+  let { extend } = actions
   extend(child, { error: null })
   try {
     if (child.children)

--- a/packages/client/src/validation.js
+++ b/packages/client/src/validation.js
@@ -3,14 +3,15 @@ import F from 'futil'
 
 // Aync fn to inspect types.
 // ASYNC runValidate: return true -> proceed, return false -> exclude, throw -> error!
-export let validate = _.curry(async (runValidate, extend, child) => {
+export let validate = _.curry(async (runValidate, actions, child) => {
+  let {extend} = actions
   extend(child, { error: null })
   try {
     if (child.children)
-      await F.flowAsync(_.map)(validate(runValidate, extend), child.children)
+      await F.flowAsync(_.map)(validate(runValidate, actions), child.children)
     let hasValue = child.children
       ? _.some('hasValue', child.children)
-      : await runValidate(child, extend)
+      : await runValidate(child, actions)
     extend(child, { hasValue })
     return hasValue
   } catch (error) {


### PR DESCRIPTION
Originally we had `runTypeFunction` that would pass only `extend` method to type functions such as `init`, `onDispatch`, `onUpdateByOthers` etc. But to be able to work with the pivot node state we often need the node in plain JS and not MOBX observable. To accommodate that `toJS` was imported directly from `mobx` which added it as a bundled dependency. 

This PR refactors `runTypeFunction` to pass down all action functions instead of just `extend` and removes `mobx` import and bundled dependency.

* [x] client: Passing actions to the `runTypeFunction`.
* [x] client: Removing bundled `mobx` dependency