### PR TITLE
Fix Serialize Issue for Keyword Generations

### DIFF
--- a/.changeset/real-feet-prove.md
+++ b/.changeset/real-feet-prove.md
@@ -1,0 +1,5 @@
+---
+'contexture-client': patch
+---
+
+Avoid boolean for keyword generations persistance when not searching

--- a/packages/client/src/exampleTypes.js
+++ b/packages/client/src/exampleTypes.js
@@ -119,7 +119,8 @@ export default F.stampKey('type', {
         keywordGenerations: {},
       },
     },
-    onSerialize: _.omit('generateKeywords'),
+    onSerialize: (node, {search}) => 
+      search ? node : _.omit('generateKeywords', node),
     shouldMergeResponse: (node) => !node.generateKeywords,
     mergeResponse(node, response, extend) {
       // extend but always persist keywordGenerations when appropriate

--- a/packages/client/src/exampleTypes.js
+++ b/packages/client/src/exampleTypes.js
@@ -119,7 +119,7 @@ export default F.stampKey('type', {
         keywordGenerations: {},
       },
     },
-    onSerialize: (node, {search}) => 
+    onSerialize: (node, { search }) =>
       search ? node : _.omit('generateKeywords', node),
     shouldMergeResponse: (node) => !node.generateKeywords,
     mergeResponse(node, response, extend) {

--- a/packages/client/src/serialize.js
+++ b/packages/client/src/serialize.js
@@ -21,14 +21,14 @@ let mapTree = (fn, tree) =>
     fn(tree)
   )
 
-export default (tree, types, { search } = {}) => {
+export default (tree, types, options = {}) => {
   let onSerialize = (node) =>
-    runTypeFunctionOrDefault(_.identity, types, 'onSerialize', node, {})
+    runTypeFunctionOrDefault(_.identity, types, 'onSerialize', node, options)
 
-  let internalKeys = _.without(search && ['lastUpdateTime'], internalStateKeys)
+  let internalKeys = _.without(options.search && ['lastUpdateTime'], internalStateKeys)
 
   let setFilterOnly = F.when(
-    (node) => search && isFilterOnly(node),
+    (node) => options.search && isFilterOnly(node),
     _.set('filterOnly', true)
   )
 

--- a/packages/client/src/serialize.js
+++ b/packages/client/src/serialize.js
@@ -25,7 +25,10 @@ export default (tree, types, options = {}) => {
   let onSerialize = (node) =>
     runTypeFunctionOrDefault(_.identity, types, 'onSerialize', node, options)
 
-  let internalKeys = _.without(options.search && ['lastUpdateTime'], internalStateKeys)
+  let internalKeys = _.without(
+    options.search && ['lastUpdateTime'],
+    internalStateKeys
+  )
 
   let setFilterOnly = F.when(
     (node) => options.search && isFilterOnly(node),


### PR DESCRIPTION
## Summary 
onSerialize was hiding the toggle for keyword generations during searches and this PR corrects this problem. 