### PR TITLE
Fix MergeResponse Call for Keyword Generations

### DIFF
--- a/.changeset/perfect-files-mate.md
+++ b/.changeset/perfect-files-mate.md
@@ -1,0 +1,5 @@
+---
+'contexture-client': patch
+---
+
+Fix access to extend function within mergeResponse for keyword generations.

--- a/packages/client/src/exampleTypes.js
+++ b/packages/client/src/exampleTypes.js
@@ -122,7 +122,8 @@ export default F.stampKey('type', {
     onSerialize: (node, { search }) =>
       search ? node : _.omit('generateKeywords', node),
     shouldMergeResponse: (node) => !node.generateKeywords,
-    mergeResponse(node, response, extend) {
+    mergeResponse(node, response, {extend}) {
+      console.log("Merge Response", extend)
       // extend but always persist keywordGenerations when appropriate
       extend(node, {
         context: {

--- a/packages/client/src/exampleTypes.js
+++ b/packages/client/src/exampleTypes.js
@@ -123,7 +123,6 @@ export default F.stampKey('type', {
       search ? node : _.omit('generateKeywords', node),
     shouldMergeResponse: (node) => !node.generateKeywords,
     mergeResponse(node, response, {extend}) {
-      console.log("Merge Response", extend)
       // extend but always persist keywordGenerations when appropriate
       extend(node, {
         context: {

--- a/packages/client/src/exampleTypes.js
+++ b/packages/client/src/exampleTypes.js
@@ -122,7 +122,7 @@ export default F.stampKey('type', {
     onSerialize: (node, { search }) =>
       search ? node : _.omit('generateKeywords', node),
     shouldMergeResponse: (node) => !node.generateKeywords,
-    mergeResponse(node, response, {extend}) {
+    mergeResponse(node, response, { extend }) {
       // extend but always persist keywordGenerations when appropriate
       extend(node, {
         context: {


### PR DESCRIPTION
## Summary 
MergeResponse function was updated, and this PR corrects access to a function that was needed for keyword generations. 