### PR TITLE
Deduplication Using Lowercase for Keyword Generations

### DIFF
--- a/.changeset/beige-sheep-hammer.md
+++ b/.changeset/beige-sheep-hammer.md
@@ -1,0 +1,5 @@
+---
+'contexture-react': patch
+---
+
+Deduplicate keyword generations with lower case to dedup regardless of casing

--- a/packages/react/src/exampleTypes/ExpandableTagsQuery/index.js
+++ b/packages/react/src/exampleTypes/ExpandableTagsQuery/index.js
@@ -133,10 +133,7 @@ let ExpandableTagsQuery = ({
               />
             ))(
               _.reject(
-                _.includes(
-                  _, 
-                  keysToLower(node.context.tags)
-                ),
+                _.includes(_, keysToLower(node.context.tags)),
                 keysToLower(node.context.keywordGenerations)
               )
             )}

--- a/packages/react/src/exampleTypes/ExpandableTagsQuery/index.js
+++ b/packages/react/src/exampleTypes/ExpandableTagsQuery/index.js
@@ -132,8 +132,11 @@ let ExpandableTagsQuery = ({
               />
             ))(
               _.reject(
-                _.includes(_, _.memoize(_.keys)(node.context.tags)),
-                _.keys(node.context.keywordGenerations)
+                _.includes(
+                  _, 
+                  _.memoize(_.flow(_.keys, _.map(_.toLower)))(node.context.tags)
+                ),
+                _.flow(_.keys, _.map(_.toLower))(node.context.keywordGenerations)
               )
             )}
         </div>

--- a/packages/react/src/exampleTypes/ExpandableTagsQuery/index.js
+++ b/packages/react/src/exampleTypes/ExpandableTagsQuery/index.js
@@ -133,10 +133,13 @@ let ExpandableTagsQuery = ({
             ))(
               _.reject(
                 _.includes(
-                  _, 
+                  _,
                   _.memoize(_.flow(_.keys, _.map(_.toLower)))(node.context.tags)
                 ),
-                _.flow(_.keys, _.map(_.toLower))(node.context.keywordGenerations)
+                _.flow(
+                  _.keys,
+                  _.map(_.toLower)
+                )(node.context.keywordGenerations)
               )
             )}
         </div>

--- a/packages/react/src/exampleTypes/ExpandableTagsQuery/index.js
+++ b/packages/react/src/exampleTypes/ExpandableTagsQuery/index.js
@@ -13,6 +13,7 @@ import ActionsMenu from '../TagsQuery/ActionsMenu.js'
 import { useOutsideClick } from '@chakra-ui/react-use-outside-click'
 import { sanitizeTagInputs } from 'contexture-elasticsearch/utils/keywordGenerations.js'
 
+let keysToLower = _.flow(_.keys, _.map(_.toLower))
 let innerHeightLimit = 40
 let addIcon = <i style={{ paddingLeft: '8px' }} className="fa fa-plus fa-sm" />
 let BlankRemoveIcon = () => <div style={{ padding: 3 }} />
@@ -134,9 +135,9 @@ let ExpandableTagsQuery = ({
               _.reject(
                 _.includes(
                   _, 
-                  _.memoize(_.flow(_.keys, _.map(_.toLower)))(node.context.tags)
+                  _.memoize(keysToLower)(node.context.tags)
                 ),
-                _.flow(_.keys, _.map(_.toLower))(node.context.keywordGenerations)
+                keysToLower(node.context.keywordGenerations)
               )
             )}
         </div>


### PR DESCRIPTION
## Summary 
Keyword generations need to be unique, regardless of the casing that is used for the words.