### PR TITLE
Update Adding Functionality of Keyword Generations 

### DIFF
--- a/.changeset/fifty-islands-retire.md
+++ b/.changeset/fifty-islands-retire.md
@@ -1,0 +1,6 @@
+---
+'contexture-elasticsearch': patch
+'contexture-react': patch
+---
+
+Fixed various bugs related to keyword generations

--- a/.changeset/lovely-bees-destroy.md
+++ b/.changeset/lovely-bees-destroy.md
@@ -1,0 +1,5 @@
+---
+'contexture-react': patch
+---
+
+Update loading behaviour between keyword generation additions

--- a/packages/provider-elasticsearch/src/example-types/filters/tagsQuery.js
+++ b/packages/provider-elasticsearch/src/example-types/filters/tagsQuery.js
@@ -106,7 +106,7 @@ let buildResultQuery = (
           filters: F.compactObject(
             F.keysToObject(
               (word) => filter({ ...node, tags: [{ word }] }),
-              keywordGenerations
+              _.map(_.toLower, keywordGenerations)
             )
           ),
         },

--- a/packages/react/src/exampleTypes/ExpandableTagsQuery/KeywordGenerations.js
+++ b/packages/react/src/exampleTypes/ExpandableTagsQuery/KeywordGenerations.js
@@ -15,7 +15,7 @@ let KeywordGenerations = ({
   Tag,
   generationsCollapsed,
   Loader,
-  style
+  style,
 }) => (
   <div style={!F.view(generationsCollapsed) ? style : { display: 'none' }}>
     {node.isStale && node.generateKeywords && (

--- a/packages/react/src/exampleTypes/ExpandableTagsQuery/KeywordGenerations.js
+++ b/packages/react/src/exampleTypes/ExpandableTagsQuery/KeywordGenerations.js
@@ -15,9 +15,8 @@ let KeywordGenerations = ({
   Tag,
   generationsCollapsed,
   Loader,
-  style,
 }) => (
-  <div style={!F.view(generationsCollapsed) ? style : { display: 'none' }}>
+  <div style={!F.view(generationsCollapsed) ? {} : { display: 'none' }}>
     {node.isStale && node.generateKeywords && (
       <Loader style={{ textAlign: 'center' }} loading={true}>
         Loading...

--- a/packages/react/src/exampleTypes/ExpandableTagsQuery/KeywordGenerations.js
+++ b/packages/react/src/exampleTypes/ExpandableTagsQuery/KeywordGenerations.js
@@ -34,7 +34,7 @@ let KeywordGenerations =
           >
             {node.isStale && node.generateKeywords && (
               <Loader style={{ textAlign: 'center' }} loading={true}>
-                Loading...23
+                Loading...
               </Loader>
             )}
             {!node.generateKeywords &&

--- a/packages/react/src/exampleTypes/ExpandableTagsQuery/KeywordGenerations.js
+++ b/packages/react/src/exampleTypes/ExpandableTagsQuery/KeywordGenerations.js
@@ -3,7 +3,6 @@ import _ from 'lodash/fp.js'
 import F from 'futil'
 import { observer } from 'mobx-react'
 import { toNumber } from '../../utils/format.js'
-import { Flex } from '../../greyVest/index.js'
 import { convertWordToTag } from '../TagsQuery/utils.js'
 
 let keysToLower = _.flow(_.keys, _.map(_.toLower))
@@ -16,56 +15,44 @@ let KeywordGenerations = ({
   Tag,
   generationsCollapsed,
   Loader,
+  style
 }) => (
-  <Flex>
-    <div
-      style={
-        !F.view(generationsCollapsed)
-          ? {
-              width: '100%',
-              marginTop: 20,
-              position: 'relative',
-              borderTop: '2px solid #EBEBEB',
-            }
-          : { display: 'none' }
-      }
-    >
-      {node.isStale && node.generateKeywords && (
-        <Loader style={{ textAlign: 'center' }} loading={true}>
-          Loading...
-        </Loader>
+  <div style={!F.view(generationsCollapsed) ? style : { display: 'none' }}>
+    {node.isStale && node.generateKeywords && (
+      <Loader style={{ textAlign: 'center' }} loading={true}>
+        Loading...
+      </Loader>
+    )}
+    {!node.generateKeywords &&
+      _.map((word) => (
+        <Tag
+          tree={tree}
+          node={node}
+          onClick={({ value, label }) =>
+            tree.mutate(node.path, {
+              tags: [...node.tags, convertWordToTag(value, label)],
+            })
+          }
+          AddIcon={addIcon}
+          key={`tag-${word}`}
+          RemoveIcon={BlankRemoveIcon}
+          tagStyle={{
+            borderRadius: '3px',
+            padding: '2px 0px',
+            backgroundColor: '#E2E2E2',
+          }}
+          value={`${word}`}
+          label={`${word} (${toNumber(
+            _.get(`context.keywordGenerations.${word}`)(node)
+          )})`}
+        />
+      ))(
+        _.reject(
+          _.includes(_, _.map('word', node.tags)),
+          keysToLower(node.context?.keywordGenerations)
+        )
       )}
-      {!node.generateKeywords &&
-        _.map((word) => (
-          <Tag
-            tree={tree}
-            node={node}
-            onClick={({ value, label }) =>
-              tree.mutate(node.path, {
-                tags: [...node.tags, convertWordToTag(value, label)],
-              })
-            }
-            AddIcon={addIcon}
-            key={`tag-${word}`}
-            RemoveIcon={BlankRemoveIcon}
-            tagStyle={{
-              borderRadius: '3px',
-              padding: '2px 0px',
-              backgroundColor: '#E2E2E2',
-            }}
-            value={`${word}`}
-            label={`${word} (${toNumber(
-              _.get(`context.keywordGenerations.${word}`)(node)
-            )})`}
-          />
-        ))(
-          _.reject(
-            _.includes(_, _.map('word', node.tags)),
-            keysToLower(node.context?.keywordGenerations)
-          )
-        )}
-    </div>
-  </Flex>
+  </div>
 )
 
 export default observer(KeywordGenerations)

--- a/packages/react/src/exampleTypes/ExpandableTagsQuery/KeywordGenerations.js
+++ b/packages/react/src/exampleTypes/ExpandableTagsQuery/KeywordGenerations.js
@@ -6,68 +6,66 @@ import { toNumber } from '../../utils/format.js'
 import { Flex } from '../../greyVest/index.js'
 import { convertWordToTag } from '../TagsQuery/utils.js'
 
-
 let keysToLower = _.flow(_.keys, _.map(_.toLower))
 let addIcon = <i style={{ paddingLeft: '8px' }} className="fa fa-plus fa-sm" />
 let BlankRemoveIcon = () => <div style={{ padding: 3 }} />
 
-let KeywordGenerations = 
-    ({
-      node,
-      tree,
-      Tag,
-      generationsCollapsed,
-      Loader,
-    }) =>  (
-      <Flex>
-          <div
-            style={
-              !F.view(generationsCollapsed)
-                ? {
-                    width: '100%',
-                    marginTop: 20,
-                    position: 'relative',
-                    borderTop: '2px solid #EBEBEB',
-                  }
-                : { display: 'none' }
+let KeywordGenerations = ({
+  node,
+  tree,
+  Tag,
+  generationsCollapsed,
+  Loader,
+}) => (
+  <Flex>
+    <div
+      style={
+        !F.view(generationsCollapsed)
+          ? {
+              width: '100%',
+              marginTop: 20,
+              position: 'relative',
+              borderTop: '2px solid #EBEBEB',
             }
-          >
-            {node.isStale && node.generateKeywords && (
-              <Loader style={{ textAlign: 'center' }} loading={true}>
-                Loading...
-              </Loader>
-            )}
-            {!node.generateKeywords &&
-              _.map((word) => (
-                <Tag
-                  tree={tree}
-                  node={node}
-                  onClick={({ value, label }) =>
-                      tree.mutate(node.path, {
-                        tags: [...node.tags, convertWordToTag(value, label)],
-                      })
-                  }
-                  AddIcon={addIcon}
-                  key={`tag-${word}`}
-                  RemoveIcon={BlankRemoveIcon}
-                  tagStyle={{
-                    borderRadius: '3px',
-                    padding: '2px 0px',
-                    backgroundColor: '#E2E2E2',
-                  }}
-                  value={`${word}`}
-                  label={`${word} (${toNumber(
-                    _.get(`context.keywordGenerations.${word}`)(node)
-                  )})`}
-                />
-              ))(
-                _.reject(
-                  _.includes(_,  _.map('word', node.tags)),
-                  keysToLower(node.context?.keywordGenerations)
-                )
-              )}
-          </div>
-      </Flex>
-    )
+          : { display: 'none' }
+      }
+    >
+      {node.isStale && node.generateKeywords && (
+        <Loader style={{ textAlign: 'center' }} loading={true}>
+          Loading...
+        </Loader>
+      )}
+      {!node.generateKeywords &&
+        _.map((word) => (
+          <Tag
+            tree={tree}
+            node={node}
+            onClick={({ value, label }) =>
+              tree.mutate(node.path, {
+                tags: [...node.tags, convertWordToTag(value, label)],
+              })
+            }
+            AddIcon={addIcon}
+            key={`tag-${word}`}
+            RemoveIcon={BlankRemoveIcon}
+            tagStyle={{
+              borderRadius: '3px',
+              padding: '2px 0px',
+              backgroundColor: '#E2E2E2',
+            }}
+            value={`${word}`}
+            label={`${word} (${toNumber(
+              _.get(`context.keywordGenerations.${word}`)(node)
+            )})`}
+          />
+        ))(
+          _.reject(
+            _.includes(_, _.map('word', node.tags)),
+            keysToLower(node.context?.keywordGenerations)
+          )
+        )}
+    </div>
+  </Flex>
+)
 
-  export default observer(KeywordGenerations)
+export default observer(KeywordGenerations)

--- a/packages/react/src/exampleTypes/ExpandableTagsQuery/KeywordGenerations.js
+++ b/packages/react/src/exampleTypes/ExpandableTagsQuery/KeywordGenerations.js
@@ -52,7 +52,7 @@ let KeywordGenerations =
                   RemoveIcon={BlankRemoveIcon}
                   tagStyle={{
                     borderRadius: '3px',
-                    padding: '3px 0px',
+                    padding: '2px 0px',
                     backgroundColor: '#E2E2E2',
                   }}
                   value={`${word}`}

--- a/packages/react/src/exampleTypes/ExpandableTagsQuery/index.js
+++ b/packages/react/src/exampleTypes/ExpandableTagsQuery/index.js
@@ -133,10 +133,7 @@ let ExpandableTagsQuery = ({
               />
             ))(
               _.reject(
-                _.includes(
-                  _, 
-                  _.memoize(keysToLower)(node.context.tags)
-                ),
+                _.includes(_, _.memoize(keysToLower)(node.context.tags)),
                 keysToLower(node.context.keywordGenerations)
               )
             )}

--- a/packages/react/src/exampleTypes/ExpandableTagsQuery/index.js
+++ b/packages/react/src/exampleTypes/ExpandableTagsQuery/index.js
@@ -53,7 +53,6 @@ let ExpandableTagsQuery = ({
   node,
   ...props
 }) => {
-
   let generationsCollapsed = React.useState(true)
   let ref = React.useRef()
   useOutsideClick({
@@ -61,7 +60,8 @@ let ExpandableTagsQuery = ({
     handler: () => !hasPopover?.current && F.on(generationsCollapsed)(),
   })
 
-  let showMoreKeywordsButton = F.view(collapse) &&
+  let showMoreKeywordsButton =
+    F.view(collapse) &&
     contentRect.entry.height > innerHeightLimit &&
     !!node.tags.length
 
@@ -85,19 +85,21 @@ let ExpandableTagsQuery = ({
             />
           </div>
         </div>
-        { ( showMoreKeywordsButton && 
-            <div style={{ minHeight: 10 }}>
-              <ExpandArrow collapse={collapse} tagsLength={node.tags.length} />
-            </div>
-          )}
+        {showMoreKeywordsButton && (
+          <div style={{ minHeight: 10 }}>
+            <ExpandArrow collapse={collapse} tagsLength={node.tags.length} />
+          </div>
+        )}
       </div>
       {/*Margin is to ensure that view more(ExpandArrow) is presented nicely*/}
-      {!F.view(generationsCollapsed) && 
-        <hr style={{
-          border: '2px solid #EBEBEB', 
-          ...(showMoreKeywordsButton && {marginBottom: 20 })
-        }}/>
-      }
+      {!F.view(generationsCollapsed) && (
+        <hr
+          style={{
+            border: '2px solid #EBEBEB',
+            ...(showMoreKeywordsButton && { marginBottom: 20 }),
+          }}
+        />
+      )}
       <KeywordGenerations
         node={node}
         tree={tree}
@@ -140,7 +142,7 @@ let TagsWrapper = observer(
           ],
           node
         )
-        let tagProps = { 
+        let tagProps = {
           ...props,
           ...(!_.isNil(count) && {
             label: `${props.value} (${toNumber(count)})`,
@@ -209,7 +211,9 @@ let TagsWrapper = observer(
                 // Show suggestion lightbulb if min of 3 non numeric tags exist,
                 // including numbers ups the chance of producing bad suggestions
                 sanitizeTagInputs(node.tags)?.length > 2 &&
-                enableKeywordGenerations ? { width: 35 } : { display: 'none' }
+                enableKeywordGenerations
+                  ? { width: 35 }
+                  : { display: 'none' }
               }
               onClick={async () => {
                 // Generate keywords or show existing keywords
@@ -218,10 +222,11 @@ let TagsWrapper = observer(
                   // so that the loading indicator is shown while generating keywords
                   let collapsedState = F.view(generationsCollapsed)
                   F.off(generationsCollapsed)()
-                  if (!collapsedState || 
-                      _.isEmpty(toJS(node.context.keywordGenerations))
-                    ){ 
-                      await triggerKeywordGeneration(node, tree) 
+                  if (
+                    !collapsedState ||
+                    _.isEmpty(toJS(node.context.keywordGenerations))
+                  ) {
+                    await triggerKeywordGeneration(node, tree)
                   }
                 }
               }}

--- a/packages/react/src/exampleTypes/ExpandableTagsQuery/index.js
+++ b/packages/react/src/exampleTypes/ExpandableTagsQuery/index.js
@@ -162,7 +162,7 @@ let TagsWrapper = observer(
           data-path={node.path}
           rows={`${innerHeightLimit}px minmax(0, auto)`}
           columns="1fr auto auto"
-          style={{...style, marginBottom: 10}}
+          style={{ ...style, marginBottom: 10 }}
         >
           <GridItem height={2} place="center stretch">
             <TagsInput
@@ -255,7 +255,7 @@ let TagsWrapper = observer(
           node={node}
           tree={tree}
           Tag={Tag}
-          style={ {paddingTop: 10, borderTop: '2px solid #EBEBEB'}}
+          style={{ paddingTop: 10, borderTop: '2px solid #EBEBEB' }}
           generationsCollapsed={generationsCollapsed}
           {...props}
         />

--- a/packages/react/src/exampleTypes/ExpandableTagsQuery/index.js
+++ b/packages/react/src/exampleTypes/ExpandableTagsQuery/index.js
@@ -61,6 +61,10 @@ let ExpandableTagsQuery = ({
     handler: () => !hasPopover?.current && F.on(generationsCollapsed)(),
   })
 
+  let showMoreKeywordsButton = F.view(collapse) &&
+    contentRect.entry.height > innerHeightLimit &&
+    !!node.tags.length
+
   return (
     <div ref={ref} onMouseUp={(e) => e.stopPropagation()}>
       <div>
@@ -81,9 +85,7 @@ let ExpandableTagsQuery = ({
             />
           </div>
         </div>
-        {F.view(collapse) &&
-          contentRect.entry.height > innerHeightLimit &&
-          !!node.tags.length && (
+        { ( showMoreKeywordsButton && 
             <div style={{ minHeight: 10 }}>
               <ExpandArrow collapse={collapse} tagsLength={node.tags.length} />
             </div>
@@ -93,7 +95,7 @@ let ExpandableTagsQuery = ({
       {!F.view(generationsCollapsed) && 
         <hr style={{
           border: '2px solid #EBEBEB', 
-          ...(F.view(collapse) && {marginBottom: 20 })
+          ...(showMoreKeywordsButton && {marginBottom: 20 })
         }}/>
       }
       <KeywordGenerations

--- a/packages/react/src/exampleTypes/ExpandableTagsQuery/index.js
+++ b/packages/react/src/exampleTypes/ExpandableTagsQuery/index.js
@@ -8,12 +8,15 @@ import { observer } from 'mobx-react'
 import { toNumber } from '../../utils/format.js'
 import TagActionsMenu from '../TagsQuery/TagActionsMenu.js'
 import { Grid, GridItem, TextButton } from '../../greyVest/index.js'
-import { getTagStyle, tagValueField, convertWordToTag } from '../TagsQuery/utils.js'
+import {
+  getTagStyle,
+  tagValueField,
+  convertWordToTag,
+} from '../TagsQuery/utils.js'
 import ActionsMenu from '../TagsQuery/ActionsMenu.js'
 import { useOutsideClick } from '@chakra-ui/react-use-outside-click'
 import { sanitizeTagInputs } from 'contexture-elasticsearch/utils/keywordGenerations.js'
 import KeywordGenerations from './KeywordGenerations.js'
-
 
 let innerHeightLimit = 40
 
@@ -56,10 +59,7 @@ let ExpandableTagsQuery = ({
           }}
         >
           <div ref={measureRef}>
-            <TagsWrapper
-              {..._.omit('measure', props)}
-              node={node}
-            />
+            <TagsWrapper {..._.omit('measure', props)} node={node} />
           </div>
         </div>
         {F.view(collapse) &&
@@ -94,8 +94,7 @@ let TagsWrapper = observer(
     enableKeywordGenerations,
     ...props
   }) => {
-
-    //Handle Outside Clicks for Keyword Generations display 
+    //Handle Outside Clicks for Keyword Generations display
     let ref = React.useRef()
     let generationsCollapsed = React.useState(true)
     useOutsideClick({ ref, handler: F.on(generationsCollapsed) })
@@ -128,10 +127,12 @@ let TagsWrapper = observer(
     )
 
     return (
-      <div       ref={ref}
-      onMouseUp={(e) => {
-        e.stopPropagation()
-      }}>
+      <div
+        ref={ref}
+        onMouseUp={(e) => {
+          e.stopPropagation()
+        }}
+      >
         <Grid
           data-path={node.path}
           rows={`${innerHeightLimit}px minmax(0, auto)`}
@@ -225,13 +226,13 @@ let TagsWrapper = observer(
             </Popover>
           </GridItem>
         </Grid>
-        <KeywordGenerations 
+        <KeywordGenerations
           node={node}
           tree={tree}
           Tag={Tag}
           generationsCollapsed={generationsCollapsed}
           {...props}
-                />
+        />
       </div>
     )
   }

--- a/packages/react/src/exampleTypes/ExpandableTagsQuery/index.js
+++ b/packages/react/src/exampleTypes/ExpandableTagsQuery/index.js
@@ -109,8 +109,8 @@ let TagsWrapper = observer(
     splitCommas = true,
     maxTags = 1000,
     hasPopover,
-    generationsCollapsed: generationsCollapse,
     enableKeywordGenerations,
+    generationsCollapsed: generationsCollapse,
     ...props
   }) => {
     //Handle Outside Clicks for Keyword Generations display
@@ -162,7 +162,7 @@ let TagsWrapper = observer(
           data-path={node.path}
           rows={`${innerHeightLimit}px minmax(0, auto)`}
           columns="1fr auto auto"
-          style={style}
+          style={{...style, marginBottom: 10}}
         >
           <GridItem height={2} place="center stretch">
             <TagsInput
@@ -255,6 +255,7 @@ let TagsWrapper = observer(
           node={node}
           tree={tree}
           Tag={Tag}
+          style={ {paddingTop: 10, borderTop: '2px solid #EBEBEB'}}
           generationsCollapsed={generationsCollapsed}
           {...props}
         />


### PR DESCRIPTION
## Summary 
Changed the source of the tags from context to the tags property so that the UI does not wait for the counts to come back to re-render. Refactored the component to its own file to help clean up the large file for Expandable tags. 

### List of updates
- Allows for the user to click as many keywords as desired while the counts load, some pages are much slower for counts to come back on and this fixes that.
- Refactor code to clean up the component file in regard to keyword generations.
- Fix height of keyword generation tag buttons
