### PR TITLE
TagsQuery: do not fail when there are no tags set on context

### DIFF
--- a/.changeset/afraid-adults-flow.md
+++ b/.changeset/afraid-adults-flow.md
@@ -1,0 +1,5 @@
+---
+'contexture-react': patch
+---
+
+TagsQuery: Do not error out when there are no tags in context

--- a/packages/react/src/exampleTypes/ExpandableTagsQuery/index.js
+++ b/packages/react/src/exampleTypes/ExpandableTagsQuery/index.js
@@ -138,8 +138,8 @@ let ExpandableTagsQuery = ({
               />
             ))(
               _.reject(
-                _.includes(_, keysToLower(node.context.tags)),
-                keysToLower(node.context.keywordGenerations)
+                _.includes(_, keysToLower(node.context?.tags)),
+                keysToLower(node.context?.keywordGenerations)
               )
             )}
         </div>
@@ -261,7 +261,7 @@ let TagsWrapper = observer(
                   F.when(F.off(generationsCollapse)(), collapsedState)
                   if (
                     !collapsedState ||
-                    _.isEmpty(node.context.keywordGenerations)
+                    _.isEmpty(node.context?.keywordGenerations)
                   ) {
                     await triggerKeywordGeneration(node, tree)
                   }


### PR DESCRIPTION
Searches that have a tags node but no tags are failing because of this