### PR TITLE
Improve performance when determining if a node has results

### DIFF
--- a/.changeset/neat-mice-divide.md
+++ b/.changeset/neat-mice-divide.md
@@ -1,0 +1,5 @@
+---
+'contexture-client': patch
+---
+
+Improve performance when determining if a node has results

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -30,7 +30,7 @@
   },
   "homepage": "https://github.com/smartprocure/contexture/tree/main/packages/client",
   "dependencies": {
-    "futil": "^1.74.1",
+    "futil": "^1.76.0",
     "lodash": "^4.17.15"
   },
   "devDependencies": {

--- a/packages/client/src/index.js
+++ b/packages/client/src/index.js
@@ -15,13 +15,7 @@ import actions from './actions/index.js'
 import serialize from './serialize.js'
 import traversals from './traversals.js'
 import { runTypeFunction, getTypeProp } from './types.js'
-import {
-  initNode,
-  hasContext,
-  hasValue,
-  dedupeWalk,
-  hasResults,
-} from './node.js'
+import { initNode, hasContext, hasValue, dedupeWalk } from './node.js'
 import exampleTypes from './exampleTypes.js'
 import lens from './lens.js'
 import mockService from './mockService.js'
@@ -233,7 +227,7 @@ export let ContextTree = _.curry(
           if (debug && node._meta) target.metaHistory.push(node._meta)
         }
 
-        target.hasResults = hasResults(snapshot)(target)
+        target.hasResults = !!Tree.findNode(F.isNotBlank, target.context)
 
         clearUpdate(target)
 

--- a/packages/client/src/index.js
+++ b/packages/client/src/index.js
@@ -15,7 +15,13 @@ import actions from './actions/index.js'
 import serialize from './serialize.js'
 import traversals from './traversals.js'
 import { runTypeFunction, getTypeProp } from './types.js'
-import { initNode, hasContext, hasValue, dedupeWalk } from './node.js'
+import {
+  initNode,
+  hasContext,
+  hasValue,
+  dedupeWalk,
+  hasResults,
+} from './node.js'
 import exampleTypes from './exampleTypes.js'
 import lens from './lens.js'
 import mockService from './mockService.js'
@@ -227,7 +233,7 @@ export let ContextTree = _.curry(
           if (debug && node._meta) target.metaHistory.push(node._meta)
         }
 
-        target.hasResults = !!Tree.findNode(F.isNotBlank, target.context)
+        target.hasResults = hasResults(target)
 
         clearUpdate(target)
 

--- a/packages/client/src/index.test.js
+++ b/packages/client/src/index.test.js
@@ -2045,7 +2045,7 @@ let AllTests = (ContextureClient) => {
   })
   it('should support processResponseNode', () => {
     let service = jest.fn(mockService())
-    let Tree = ContextureMobx(
+    let Tree = ContextureClient(
       { service, debounce: 1 },
       {
         key: 'root',

--- a/packages/client/src/index.test.js
+++ b/packages/client/src/index.test.js
@@ -2045,7 +2045,7 @@ let AllTests = (ContextureClient) => {
   })
   it('should support processResponseNode', () => {
     let service = jest.fn(mockService())
-    let Tree = ContextureClient(
+    let Tree = ContextureMobx(
       { service, debounce: 1 },
       {
         key: 'root',

--- a/packages/client/src/node.js
+++ b/packages/client/src/node.js
@@ -75,3 +75,16 @@ export let hasValue = (node) =>
   node && _.isUndefined(node.hasValue)
     ? throwsError('Node was never validated')
     : node && node.hasValue && !node.error
+
+// Work around mobx array detection because `_.isArray(mobxArray) !== true`
+const isArrayLike = (x) =>
+  x && !_.isString(x) && _.isFunction(x[Symbol.iterator])
+
+const isTraversable = (x) => _.isPlainObject(x) || isArrayLike(x)
+
+export let hasResults = (node) =>
+  !!F.findNode()((node) => {
+    if (!isTraversable(node)) {
+      return F.isNotBlank(node)
+    }
+  }, node.context)

--- a/packages/client/src/node.js
+++ b/packages/client/src/node.js
@@ -75,6 +75,3 @@ export let hasValue = (node) =>
   node && _.isUndefined(node.hasValue)
     ? throwsError('Node was never validated')
     : node && node.hasValue && !node.error
-
-export let hasResults = (snapshot) =>
-  _.flow(_.get('context'), snapshot, _.negate(F.isBlankDeep(_.every)))

--- a/packages/client/src/node.test.js
+++ b/packages/client/src/node.test.js
@@ -1,0 +1,62 @@
+import { observable } from 'mobx'
+import { hasResults } from './node.js'
+
+describe('hasResults()', () => {
+  describe('plain traversables', () => {
+    it('should return false for empty nested objects', () => {
+      const actual = hasResults({
+        context: {
+          a: null,
+          b: '',
+          c: undefined,
+          d: [null, '', undefined],
+        },
+      })
+      expect(actual).toEqual(false)
+    })
+
+    it('should return true for empty nested objects with at least one non-empty value', () => {
+      const actual = hasResults({
+        context: {
+          a: null,
+          b: '',
+          c: undefined,
+          d: 'Leah',
+          e: [null, '', undefined],
+        },
+      })
+      expect(actual).toEqual(true)
+    })
+  })
+
+  describe('mobx traversables', () => {
+    it('should return false for empty nested objects', () => {
+      const actual = hasResults(
+        observable({
+          context: {
+            a: null,
+            b: '',
+            c: undefined,
+            d: [null, '', undefined],
+          },
+        })
+      )
+      expect(actual).toEqual(false)
+    })
+
+    it('should return true for empty nested objects with at least one non-empty value', () => {
+      const actual = hasResults(
+        observable({
+          context: {
+            a: null,
+            b: '',
+            c: undefined,
+            d: 'Leah',
+            e: [null, '', undefined],
+          },
+        })
+      )
+      expect(actual).toEqual(true)
+    })
+  })
+})

--- a/packages/export/package.json
+++ b/packages/export/package.json
@@ -30,7 +30,7 @@
   },
   "homepage": "https://github.com/smartprocure/contexture/tree/main/packages/export",
   "dependencies": {
-    "futil": "^1.74.1",
+    "futil": "^1.76.0",
     "lodash": "^4.17.21",
     "minimal-csv-formatter": "^1.0.15"
   },

--- a/packages/provider-elasticsearch/package.json
+++ b/packages/provider-elasticsearch/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "@elastic/datemath": "^2.3.0",
     "debug": "^4.3.1",
-    "futil": "^1.74.1",
+    "futil": "^1.76.0",
     "js-combinatorics": "^0.5.3",
     "lodash": "^4.17.4",
     "moment": "^2.18.1",

--- a/packages/provider-mongo/package.json
+++ b/packages/provider-mongo/package.json
@@ -38,7 +38,7 @@
     "@elastic/datemath": "^2.3.0",
     "bluebird": "^3.5.0",
     "debug": "^4.3.1",
-    "futil": "^1.74.1",
+    "futil": "^1.76.0",
     "lodash": "^4.17.4",
     "moment": "^2.18.1",
     "moment-timezone": "^0.5.28"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -74,7 +74,7 @@
   },
   "dependencies": {
     "@chakra-ui/react-use-outside-click": "^2.1.0",
-    "futil": "^1.74.1",
+    "futil": "^1.76.0",
     "lodash": "^4.17.15",
     "moment": "^2.24.0",
     "pluralize": "^8.0.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "@elastic/datemath": "^5.0.3",
     "date-fns": "^2.11.1",
-    "futil": "^1.74.1",
+    "futil": "^1.76.0",
     "lodash": "^4.17.21",
     "moment": "^2.24.0",
     "moment-timezone": "^0.5.28"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6424,7 +6424,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "contexture-client@workspace:packages/client"
   dependencies:
-    futil: ^1.74.1
+    futil: ^1.76.0
     lodash: ^4.17.15
     mobx: ^4.3.1
   languageName: unknown
@@ -6439,7 +6439,7 @@ __metadata:
     agentkeepalive: ^4.1.4
     contexture: ^0.12.19
     debug: ^4.3.1
-    futil: ^1.74.1
+    futil: ^1.76.0
     js-combinatorics: ^0.5.3
     json-stable-stringify: ^1.0.1
     lodash: ^4.17.4
@@ -6453,7 +6453,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "contexture-export@workspace:packages/export"
   dependencies:
-    futil: ^1.74.1
+    futil: ^1.76.0
     lodash: ^4.17.21
     minimal-csv-formatter: ^1.0.15
   languageName: unknown
@@ -6467,7 +6467,7 @@ __metadata:
     bluebird: ^3.5.0
     contexture: ^0.12.19
     debug: ^4.3.1
-    futil: ^1.74.1
+    futil: ^1.76.0
     lodash: ^4.17.4
     mingo: ^4.1.2
     moment: ^2.18.1
@@ -6518,7 +6518,7 @@ __metadata:
     elasticsearch-browser: ^14.2.2
     emoji-datasource: ^5.0.1
     eslint-plugin-react: ^7.32.0
-    futil: ^1.74.1
+    futil: ^1.76.0
     lodash: ^4.17.15
     material-ui-chip-input: ^1.0.0
     mobx: ^4.3.1
@@ -6554,7 +6554,7 @@ __metadata:
   dependencies:
     "@elastic/datemath": ^5.0.3
     date-fns: ^2.11.1
-    futil: ^1.74.1
+    futil: ^1.76.0
     lodash: ^4.17.21
     mockdate: ^3.0.5
     moment: ^2.24.0
@@ -8668,13 +8668,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"futil@npm:^1.74.1":
-  version: 1.74.1
-  resolution: "futil@npm:1.74.1"
+"futil@npm:^1.76.0":
+  version: 1.76.0
+  resolution: "futil@npm:1.76.0"
   dependencies:
     babel-polyfill: ^6.23.0
     lodash: ^4.17.4
-  checksum: e677c611edafd4fa31cc6f56636fccf987952e18f6a5b05021e39855bebadb0033a5f101799cd3a912c2ba6c5041c28083b9e0ffde02ebc02d8c857c7218eda6
+  checksum: a095c7ff767f5a2e1160c104067e9c170ef121dc829d29ed723890bc3abac2a8524d99c5953cd3a3caee44d966d68c8ab05c32bb2fcbf8fcd2f6725154a009b3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- Bumped futil to use `F.findNode`
- Improved performance when computing `node.hasResults`. There's no need to recurse down to every value, we just needed to find the first non-blank value.