### PR TITLE
Fix Saved Searches

### DIFF
--- a/.changeset/happy-timers-poke.md
+++ b/.changeset/happy-timers-poke.md
@@ -1,0 +1,5 @@
+---
+'contexture-client': patch
+---
+
+Fix old saved searches loading the right data from keyword generations code changes

--- a/packages/client/src/exampleTypes.js
+++ b/packages/client/src/exampleTypes.js
@@ -126,7 +126,7 @@ export default F.stampKey('type', {
       // extend but always persist keywordGenerations when appropriate
       extend(node, {
         context: {
-          keywordGenerations: node.context.keywordGenerations,
+          keywordGenerations: node?.context?.keywordGenerations,
           tags: response.context.tags,
         },
       })


### PR DESCRIPTION
## Summary 
Fixes saved searches from looking for the context of the node on merge, as sometimes this is not present in old saved searches. 