### PR TITLE
Fix for FilterOnly Tags Query

### DIFF
--- a/.changeset/sweet-experts-kick.md
+++ b/.changeset/sweet-experts-kick.md
@@ -1,0 +1,5 @@
+---
+'contexture-react': patch
+---
+
+Fix counts for filterOnly flag

--- a/packages/react/src/exampleTypes/ExpandableTagsQuery/index.js
+++ b/packages/react/src/exampleTypes/ExpandableTagsQuery/index.js
@@ -141,7 +141,7 @@ let TagsWrapper = observer(
             `context.keywordGenerations.${props.value}`,
           ],
           node,
-          0
+          node.forceFilterOnly ? undefined : 0 
         )
         let tagProps = {
           ...props,

--- a/packages/react/src/exampleTypes/ExpandableTagsQuery/index.js
+++ b/packages/react/src/exampleTypes/ExpandableTagsQuery/index.js
@@ -141,7 +141,7 @@ let TagsWrapper = observer(
             `context.keywordGenerations.${props.value}`,
           ],
           node,
-          node.forceFilterOnly ? undefined : 0 
+          node.forceFilterOnly ? undefined : 0
         )
         let tagProps = {
           ...props,


### PR DESCRIPTION
## Summary 
FilterOnly tags query counts  should come back as undefined as they always have. This corrects the case of its use within transcript searches in that a zero does not show, as the counts are not queried from aggs in this instance.