### PR TITLE
UI Improvements for Keyword Generations

### DIFF
--- a/.changeset/kind-ants-kneel.md
+++ b/.changeset/kind-ants-kneel.md
@@ -1,0 +1,5 @@
+---
+'contexture-react': patch
+---
+
+- Updated look and feel of keyword generations UI, along with some worflow updates and a new tool tip bar that will later house the settings for generations as well.

--- a/packages/react/src/exampleTypes/ExpandableTagsQuery/KeywordGenerations.js
+++ b/packages/react/src/exampleTypes/ExpandableTagsQuery/KeywordGenerations.js
@@ -7,11 +7,18 @@ import { convertWordToTag } from '../TagsQuery/utils.js'
 
 let keysToLower = _.flow(_.keys, _.map(_.toLower))
 
-let addIcon = <i className="material-icons" style={{ padding: '0px 2px', fontSize: 'small' }}>add</i>
+let addIcon = (
+  <i
+    className="material-icons"
+    style={{ padding: '0px 2px', fontSize: 'small' }}
+  >
+    add
+  </i>
+)
 let BlankRemoveIcon = () => <div style={{ padding: 3 }} />
 let tipStrings = [
-  "Click the keyword generator icon again to regenerate new suggestions based on the keywords selected for your search.",
-  "Click on a keyword to add it to your search."
+  'Click the keyword generator icon again to regenerate new suggestions based on the keywords selected for your search.',
+  'Click on a keyword to add it to your search.',
 ]
 
 let KeywordGenerations = ({
@@ -22,19 +29,16 @@ let KeywordGenerations = ({
   innerEdgeMargins = {},
   Loader,
 }) => {
-
   let [tips, setTips] = React.useState([...tipStrings])
-  React.useEffect(()=>{
+  React.useEffect(() => {
     F.when(
-      setTips((tips)=>[_.last(tips), ..._.dropRight(1, tips)]), 
+      setTips((tips) => [_.last(tips), ..._.dropRight(1, tips)]),
       F.view(generationsCollapsed)
     )
   }, [generationsCollapsed])
-  
+
   return (
-    <div style={
-        !F.view(generationsCollapsed) ? {} : { display: 'none' }
-      }>
+    <div style={!F.view(generationsCollapsed) ? {} : { display: 'none' }}>
       <div>
         {node.isStale && node.generateKeywords && (
           <Loader style={{ textAlign: 'center' }} loading={true}>
@@ -72,33 +76,37 @@ let KeywordGenerations = ({
             )
           )}
       </div>
-      <div style={
-          {
-            ...(!_.isEmpty(innerEdgeMargins) && {
-              marginRight: innerEdgeMargins.marginRight,
-              marginLeft: innerEdgeMargins.marginLeft,
-              marginBottom: innerEdgeMargins.marginBottom,
-            }),
-            backgroundColor:'#f5f5f5',
-            marginTop: '12px',
-            padding: '4px 12px',
-            borderBottomRightRadius: 3, 
-            borderBottomLeftRadius: 3,
-            display: 'grid',
-            gridTemplateColumns: '18px 1fr'
-          }
-        }>
-        <i className="material-icons" style={{ margin: 'auto 0', padding: '0px 2px', fontSize: 'small' }}>info</i>
-        <span style={
-          {
+      <div
+        style={{
+          ...(!_.isEmpty(innerEdgeMargins) && {
+            marginRight: innerEdgeMargins.marginRight,
+            marginLeft: innerEdgeMargins.marginLeft,
+            marginBottom: innerEdgeMargins.marginBottom,
+          }),
+          backgroundColor: '#f5f5f5',
+          marginTop: '12px',
+          padding: '4px 12px',
+          borderBottomRightRadius: 3,
+          borderBottomLeftRadius: 3,
+          display: 'grid',
+          gridTemplateColumns: '18px 1fr',
+        }}
+      >
+        <i
+          className="material-icons"
+          style={{ margin: 'auto 0', padding: '0px 2px', fontSize: 'small' }}
+        >
+          info
+        </i>
+        <span
+          style={{
             fontFamily: 'Lato',
             fontSize: '9px',
             fontWeight: 'normal',
             fontStretch: 'normal',
             fontStyle: 'italic',
             margin: 'auto 0',
-          }
-        }
+          }}
         >
           Tip: {tips[0]}
         </span>

--- a/packages/react/src/exampleTypes/ExpandableTagsQuery/KeywordGenerations.js
+++ b/packages/react/src/exampleTypes/ExpandableTagsQuery/KeywordGenerations.js
@@ -6,52 +6,104 @@ import { toNumber } from '../../utils/format.js'
 import { convertWordToTag } from '../TagsQuery/utils.js'
 
 let keysToLower = _.flow(_.keys, _.map(_.toLower))
-let addIcon = <i style={{ paddingLeft: '8px' }} className="fa fa-plus fa-sm" />
+
+let addIcon = <i className="material-icons" style={{ padding: '0px 2px', fontSize: 'small' }}>add</i>
 let BlankRemoveIcon = () => <div style={{ padding: 3 }} />
+let tipStrings = [
+  "Click the keyword generator icon again to regenerate new suggestions based on the keywords selected for your search.",
+  "Click on a keyword to add it to your search."
+]
 
 let KeywordGenerations = ({
   node,
   tree,
   Tag,
   generationsCollapsed,
+  innerEdgeMargins = {},
   Loader,
-}) => (
-  <div style={!F.view(generationsCollapsed) ? {} : { display: 'none' }}>
-    {node.isStale && node.generateKeywords && (
-      <Loader style={{ textAlign: 'center' }} loading={true}>
-        Loading...
-      </Loader>
-    )}
-    {!node.generateKeywords &&
-      _.map((word) => (
-        <Tag
-          tree={tree}
-          node={node}
-          onClick={({ value, label }) =>
-            tree.mutate(node.path, {
-              tags: [...node.tags, convertWordToTag(value, label)],
-            })
-          }
-          AddIcon={addIcon}
-          key={`tag-${word}`}
-          RemoveIcon={BlankRemoveIcon}
-          tagStyle={{
-            borderRadius: '3px',
-            padding: '2px 0px',
-            backgroundColor: '#E2E2E2',
-          }}
-          value={`${word}`}
-          label={`${word} (${toNumber(
-            _.get(`context.keywordGenerations.${word}`)(node)
-          )})`}
-        />
-      ))(
-        _.reject(
-          _.includes(_, _.map('word', node.tags)),
-          keysToLower(node.context?.keywordGenerations)
-        )
-      )}
-  </div>
-)
+}) => {
 
+  let [tips, setTips] = React.useState([...tipStrings])
+  React.useEffect(()=>{
+    F.when(
+      setTips((tips)=>[_.last(tips), ..._.dropRight(1, tips)]), 
+      F.view(generationsCollapsed)
+    )
+  }, [generationsCollapsed])
+  
+  return (
+    <div style={
+        !F.view(generationsCollapsed) ? {} : { display: 'none' }
+      }>
+      <div>
+        {node.isStale && node.generateKeywords && (
+          <Loader style={{ textAlign: 'center' }} loading={true}>
+            Loading...
+          </Loader>
+        )}
+        {!node.generateKeywords &&
+          _.map((word) => (
+            <Tag
+              tree={tree}
+              node={node}
+              onClick={({ value, label }) =>
+                tree.mutate(node.path, {
+                  tags: [...node.tags, convertWordToTag(value, label)],
+                })
+              }
+              AddIcon={addIcon}
+              key={`tag-${word}`}
+              RemoveIcon={BlankRemoveIcon}
+              hoverColor={'#A9A9A9'}
+              tagStyle={{
+                borderRadius: '3px',
+                padding: '0px 0px',
+                backgroundColor: '#E2E2E2',
+              }}
+              value={`${word}`}
+              label={`${word} (${toNumber(
+                _.get(`context.keywordGenerations.${word}`)(node)
+              )})`}
+            />
+          ))(
+            _.reject(
+              _.includes(_, _.map('word', node.tags)),
+              keysToLower(node.context?.keywordGenerations)
+            )
+          )}
+      </div>
+      <div style={
+          {
+            ...(!_.isEmpty(innerEdgeMargins) && {
+              marginRight: innerEdgeMargins.marginRight,
+              marginLeft: innerEdgeMargins.marginLeft,
+              marginBottom: innerEdgeMargins.marginBottom,
+            }),
+            backgroundColor:'#f5f5f5',
+            marginTop: '12px',
+            padding: '4px 12px',
+            borderBottomRightRadius: 3, 
+            borderBottomLeftRadius: 3,
+            display: 'grid',
+            gridTemplateColumns: '18px 1fr'
+          }
+        }>
+        <i className="material-icons" style={{ margin: 'auto 0', padding: '0px 2px', fontSize: 'small' }}>info</i>
+        <span style={
+          {
+            fontFamily: 'Lato',
+            fontSize: '9px',
+            fontWeight: 'normal',
+            fontStretch: 'normal',
+            fontStyle: 'italic',
+            margin: 'auto 0',
+          }
+        }
+        >
+          Tip: {tips[0]}
+        </span>
+      </div>
+    </div>
+  )
+}
 export default observer(KeywordGenerations)

--- a/packages/react/src/exampleTypes/ExpandableTagsQuery/index.js
+++ b/packages/react/src/exampleTypes/ExpandableTagsQuery/index.js
@@ -26,7 +26,7 @@ let triggerKeywordGeneration = async (node, tree) => {
   tree.mutate(node.path, { generateKeywords: false })
 }
 
-let KeywordGenerationIcon = ({strokeColor = 'currentColor'}) => (
+let KeywordGenerationIcon = ({ strokeColor = 'currentColor' }) => (
   <svg
     xmlns="http://www.w3.org/2000/svg"
     className="h-6 w-6"
@@ -56,7 +56,7 @@ let ExpandableTagsQuery = ({
   ...props
 }) => {
   let generationsCollapsed = React.useState(true)
-  let {marginRight, marginLeft} = innerEdgeMargins
+  let { marginRight, marginLeft } = innerEdgeMargins
   let ref = React.useRef()
   useOutsideClick({
     ref,
@@ -95,16 +95,16 @@ let ExpandableTagsQuery = ({
         )}
       </div>
       {/*Margin is to ensure that view more(ExpandArrow) is presented nicely*/}
-      {!F.view(generationsCollapsed) && 
+      {!F.view(generationsCollapsed) && (
         <hr
           style={{
             border: '2px solid #EBEBEB',
-            ...(!_.isEmpty(innerEdgeMargins) && {marginLeft, marginRight}),
-            ...(!F.view(collapse) && {marginBottom: '10px'}),
+            ...(!_.isEmpty(innerEdgeMargins) && { marginLeft, marginRight }),
+            ...(!F.view(collapse) && { marginBottom: '10px' }),
             ...(showMoreKeywordsButton && { marginBottom: 20 }),
           }}
         />
-      }
+      )}
       <KeywordGenerations
         node={node}
         tree={tree}
@@ -113,7 +113,6 @@ let ExpandableTagsQuery = ({
         innerEdgeMargins={innerEdgeMargins}
         {...props}
       />
-      
     </div>
   )
 }
@@ -188,9 +187,10 @@ let TagsWrapper = observer(
               sanitizeTags={sanitizeTags}
               maxTags={maxTags}
               wordsMatchPattern={wordsMatchPattern}
-              tags={node.tags?.length > 0 ? 
-                _.map(tagValueField, node.tags) : 
-                F.on(generationsCollapsed)()
+              tags={
+                node.tags?.length > 0
+                  ? _.map(tagValueField, node.tags)
+                  : F.on(generationsCollapsed)()
               }
               onTagsDropped={onTagsDropped}
               addTags={(addedTags) => {
@@ -225,7 +225,7 @@ let TagsWrapper = observer(
                 sanitizeTagInputs(node.tags)?.length > 2 &&
                 enableKeywordGenerations
                   ? { width: 35, strokeOpacity: 1 }
-                  : { width: 35, strokeOpacity: 0.5}
+                  : { width: 35, strokeOpacity: 0.5 }
               }
               onClick={async () => {
                 // Generate keywords or show existing keywords
@@ -243,11 +243,14 @@ let TagsWrapper = observer(
                 }
               }}
             >
-              <KeywordGenerationIcon 
-                strokeColor={ 
+              <KeywordGenerationIcon
+                strokeColor={
                   sanitizeTagInputs(node.tags)?.length > 2 &&
-                  enableKeywordGenerations ? 'rgb(92, 184, 92)' : 'currentColor'
-                }/>
+                  enableKeywordGenerations
+                    ? 'rgb(92, 184, 92)'
+                    : 'currentColor'
+                }
+              />
             </TextButton>
           </GridItem>
           <GridItem place="center">

--- a/packages/react/src/exampleTypes/TagsQuerySearchBar.js
+++ b/packages/react/src/exampleTypes/TagsQuerySearchBar.js
@@ -15,6 +15,14 @@ let searchBarStyle = {
 let searchBarBoxStyle = {
   padding: '8px 10px',
   flex: 1,
+  borderBottomRightRadius: '3px'
+}
+
+let innerEdgeMargins = {
+  marginRight: '-10px',
+  marginLeft: '-10px',
+  marginTop: '-8px',
+  marginBottom: '-8px',
 }
 
 let inputStyle = {
@@ -89,6 +97,7 @@ let SearchBar = ({
             hasPopover,
             actionWrapper,
             enableKeywordGenerations,
+            innerEdgeMargins,
           }}
           onAddTag={F.off(collapse)}
           Loader={({ children, ...props }) => (

--- a/packages/react/src/exampleTypes/TagsQuerySearchBar.js
+++ b/packages/react/src/exampleTypes/TagsQuerySearchBar.js
@@ -15,7 +15,7 @@ let searchBarStyle = {
 let searchBarBoxStyle = {
   padding: '8px 10px',
   flex: 1,
-  borderBottomRightRadius: '3px'
+  borderBottomRightRadius: '3px',
 }
 
 let innerEdgeMargins = {

--- a/packages/react/src/greyVest/Tag.js
+++ b/packages/react/src/greyVest/Tag.js
@@ -17,40 +17,47 @@ let Tag = ({
   AddIcon = null,
   tagStyle,
   onClick,
-}) => (
-  <span
-    className="tags-input-tag"
-    style={{
-      display: 'inline-block',
-      cursor: 'pointer',
-      margin: '4px 3px',
-      borderRadius: '3px',
-      wordBreak: 'break-all',
-      ...F.callOrReturn(tagStyle, value),
-    }}
-    onClick={() => onClick({ value, label })}
-  >
-    <Flex style={{ alignItems: 'center' }}>
-      {AddIcon}
-      <span
-        style={{
-          paddingLeft: '0.45em',
-          paddingBottom: '0.15em',
-          // Prefer padding on the remove icon so it has more area to receive
-          // clicks
-          paddingRight: RemoveTagIcon ? '0em' : '0.45em',
-        }}
-      >
-        {label || value}
-      </span>
-      <RemoveIcon
-        onClick={(e) => {
-          e.stopPropagation()
-          removeTag(value)
-        }}
-      />
-    </Flex>
-  </span>
-)
+  hoverColor,
+}) => {
+  let [hoverState, setHoverState] = React.useState(false)
+  return (
+    <span
+      className="tags-input-tag"
+      style={{
+        display: 'inline-block',
+        cursor: 'pointer',
+        margin: '4px 3px',
+        borderRadius: '3px',
+        wordBreak: 'break-all',
+        ...F.callOrReturn(tagStyle, value),
+       ...( hoverState && hoverColor && {backgroundColor: hoverColor} )
+      }}
+      onClick={() => onClick({ value, label })}
+      onMouseEnter={() => setHoverState(true)}
+      onMouseLeave={() => setHoverState(false)}
+    >
+      <Flex style={{ alignItems: 'center' }}>
+        {AddIcon}
+        <span
+          style={{
+           ...( !AddIcon && {paddingLeft: '0.45em'}),
+            paddingBottom: '0.15em',
+            // Prefer padding on the remove icon so it has more area to receive
+            // clicks
+            paddingRight: RemoveTagIcon ? '0em' : '0.45em',
+          }}
+        >
+          {label || value}
+        </span>
+        <RemoveIcon
+          onClick={(e) => {
+            e.stopPropagation()
+            removeTag(value)
+          }}
+        />
+      </Flex>
+    </span>
+  )
+}
 
 export default observer(Tag)

--- a/packages/react/src/greyVest/Tag.js
+++ b/packages/react/src/greyVest/Tag.js
@@ -30,7 +30,7 @@ let Tag = ({
         borderRadius: '3px',
         wordBreak: 'break-all',
         ...F.callOrReturn(tagStyle, value),
-       ...( hoverState && hoverColor && {backgroundColor: hoverColor} )
+        ...(hoverState && hoverColor && { backgroundColor: hoverColor }),
       }}
       onClick={() => onClick({ value, label })}
       onMouseEnter={() => setHoverState(true)}
@@ -40,7 +40,7 @@ let Tag = ({
         {AddIcon}
         <span
           style={{
-           ...( !AddIcon && {paddingLeft: '0.45em'}),
+            ...(!AddIcon && { paddingLeft: '0.45em' }),
             paddingBottom: '0.15em',
             // Prefer padding on the remove icon so it has more area to receive
             // clicks


### PR DESCRIPTION
## Summary 
Updated workflow to hide keyword generations in certain cases that involve the toggle to use keyword generations being no longer active, in the case of clearing/removing enough to disable the button. 

Updated various UI elements related to keyword generations requested that can be found in the mocks related to this item. On top of these there is now an additional element in the generations component to showcase tooltips and for future settings to be placed within. 

