### PR TITLE
Upgrade react-dnd

### DIFF
--- a/.changeset/friendly-swans-press.md
+++ b/.changeset/friendly-swans-press.md
@@ -1,0 +1,5 @@
+---
+'contexture-react': minor
+---
+
+Upgrade react-dnd

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -80,8 +80,8 @@
     "pluralize": "^8.0.0",
     "prop-types": "^15.7.2",
     "react-date-picker": "^7.2.0",
-    "react-dnd": "^2.5.4",
-    "react-dnd-html5-backend": "^2.5.4",
+    "react-dnd": "^16.0.1",
+    "react-dnd-html5-backend": "^16.0.1",
     "react-measure": "^2.3.0",
     "react-recompose": "^0.31.2",
     "reactjs-popup": "^2.0.4"

--- a/packages/react/src/queryBuilder/DragDrop/DDContext.js
+++ b/packages/react/src/queryBuilder/DragDrop/DDContext.js
@@ -1,4 +1,0 @@
-import { DragDropContext } from 'react-dnd'
-import HTML5Backend from 'react-dnd-html5-backend'
-
-export default DragDropContext(HTML5Backend)

--- a/packages/react/src/queryBuilder/DragDrop/FilterDragSource.js
+++ b/packages/react/src/queryBuilder/DragDrop/FilterDragSource.js
@@ -1,16 +1,13 @@
-import { DragSource } from 'react-dnd'
+import { useDrag } from 'react-dnd'
 
-export default DragSource(
-  'filter',
-  {
-    beginDrag: (props) => ({
+export default (props) =>
+  useDrag({
+    type: 'filter',
+    item: {
       node: props.child || props.node,
       tree: props.tree,
+    },
+    collect: (monitor) => ({
+      isDragging: monitor.isDragging(),
     }),
-  },
-  (connect, monitor) => ({
-    connectDragSource: connect.dragSource(),
-    connectDragPreview: connect.dragPreview(),
-    isDragging: monitor.isDragging(),
   })
-)

--- a/packages/react/src/queryBuilder/DragDrop/FilterDropTarget.js
+++ b/packages/react/src/queryBuilder/DragDrop/FilterDropTarget.js
@@ -1,10 +1,13 @@
-import { DropTarget } from 'react-dnd'
+import { useDrop } from 'react-dnd'
 
-export let FilterDropTarget = (spec) =>
-  DropTarget('filter', spec, (connect, monitor) => ({
-    connectDropTarget: connect.dropTarget(),
-    isOver: monitor.isOver(),
-    canDrop: monitor.canDrop(),
-    dragItem: monitor.getItem(),
-  }))
-export default FilterDropTarget
+export let useFilterDropTarget = (spec) =>
+  useDrop({
+    accept: 'filter',
+    collect: (monitor) => ({
+      isOver: monitor.isOver(),
+      canDrop: monitor.canDrop(),
+      dragItem: monitor.getItem(),
+    }),
+    ...spec,
+  })
+export default useFilterDropTarget

--- a/packages/react/src/queryBuilder/DragDrop/IndentTarget.js
+++ b/packages/react/src/queryBuilder/DragDrop/IndentTarget.js
@@ -1,49 +1,39 @@
 import React from 'react'
-import { FilterDropTarget } from './FilterDropTarget.js'
+import { useFilterDropTarget } from './FilterDropTarget.js'
 import styles from '../../styles/index.js'
 import { oppositeJoin, indent } from '../../utils/search.js'
 
-// Indent
-let FilterIndentSpec = {
-  drop(props, monitor) {
-    let source = monitor.getItem()
-    let isSelf = props.child === source.node
-    if (isSelf) {
-      props.tree.remove(props.child)
-    } else {
-      let newGroup = indent(props.tree, props.node, props.child, true)
-      props.tree.move(source.node.path, {
-        path: newGroup.path,
-        index: 1,
-      })
-    }
-  },
+export let FilterIndentTarget = ({ child, node, tree }) => {
+  const [{ canDrop, dragItem }, drop] = useFilterDropTarget({
+    drop(source) {
+      let isSelf = child === source.node
+      if (isSelf) {
+        tree.remove(child)
+      } else {
+        let newGroup = indent(tree, node, child, true)
+        tree.move(source.node.path, {
+          path: newGroup.path,
+          index: 1,
+        })
+      }
+    },
+  })
+  return (
+    <div ref={drop}>
+      {!child.children && canDrop && (
+        <div
+          style={{
+            width: '50%',
+            marginLeft: '50%',
+            height: 50,
+            position: 'fixed',
+            ...(dragItem.node === child
+              ? styles.bgStriped
+              : styles.bgPreview(oppositeJoin(node.join))),
+            zIndex: 100,
+          }}
+        />
+      )}
+    </div>
+  )
 }
-export let FilterIndentTarget = FilterDropTarget(FilterIndentSpec)(
-  ({
-    child,
-    node,
-    connectDropTarget,
-    // isOver,
-    canDrop,
-    dragItem,
-  }) =>
-    connectDropTarget(
-      <div>
-        {!child.children && canDrop && (
-          <div
-            style={{
-              width: '50%',
-              marginLeft: '50%',
-              height: 50,
-              position: 'fixed',
-              ...(dragItem.node === child
-                ? styles.bgStriped
-                : styles.bgPreview(oppositeJoin(node.join))),
-              zIndex: 100,
-            }}
-          />
-        )}
-      </div>
-    )
-)

--- a/packages/react/src/queryBuilder/DragDrop/MoveTargets.js
+++ b/packages/react/src/queryBuilder/DragDrop/MoveTargets.js
@@ -1,33 +1,31 @@
 import React from 'react'
-import { FilterDropTarget } from './FilterDropTarget.js'
+import { useFilterDropTarget } from './FilterDropTarget.js'
 import styles from '../../styles/index.js'
 
 // Move
-let FilterMoveSpec = {
-  drop(props, monitor) {
-    let { node } = monitor.getItem()
-    props.tree.move(node.path, {
-      path: props.node.path,
-      index: props.index,
+let FilterMoveDropTarget =
+  (style) =>
+  ({ node, tree, index }) => {
+    const [{ canDrop, isOver }, drop] = useFilterDropTarget({
+      drop(source) {
+        tree.move(source.node.path, {
+          path: node.path,
+          index: index,
+        })
+      },
     })
-  },
-}
-let FilterMoveDropTarget = (style) =>
-  FilterDropTarget(FilterMoveSpec)(
-    ({ node, connectDropTarget, isOver, canDrop }) =>
-      connectDropTarget(
-        canDrop ? (
-          <div
-            style={{
-              ...styles.bgPreview(node),
-              ...style({ isOver }),
-            }}
-          />
-        ) : (
-          <div />
-        )
-      )
-  )
+    return canDrop ? (
+      <div
+        ref={drop}
+        style={{
+          ...styles.bgPreview(node),
+          ...style({ isOver }),
+        }}
+      />
+    ) : (
+      <div />
+    )
+  }
 
 export let OperatorMoveTarget = FilterMoveDropTarget(() => ({
   width: `${styles.operatorWidth}px`,

--- a/packages/react/src/queryBuilder/FilterContents.stories.js
+++ b/packages/react/src/queryBuilder/FilterContents.stories.js
@@ -1,4 +1,3 @@
-import { root } from './stories/util.js'
 import Component from './FilterContents.js'
 
 export default {
@@ -8,7 +7,6 @@ export default {
 export const FilterContents = {
   args: {
     node: { key: 'testKey' },
-    root,
     fields: {
       test: {
         field: 'test',

--- a/packages/react/src/queryBuilder/Group.js
+++ b/packages/react/src/queryBuilder/Group.js
@@ -7,7 +7,7 @@ import Indentable from './preview/Indentable.js'
 import AddPreview from './preview/AddPreview.js'
 import Operator from './Operator.js'
 import Rule from './Rule.js'
-import FilterDragSource from './DragDrop/FilterDragSource.js'
+import useFilterDragSource from './DragDrop/FilterDragSource.js'
 import { FilterIndentTarget } from './DragDrop/IndentTarget.js'
 import { FilterMoveTarget } from './DragDrop/MoveTargets.js'
 let { background } = styles
@@ -15,25 +15,18 @@ import { blankNode } from '../utils/search.js'
 import { useLensObject } from '../utils/react.js'
 import { setDisplayName } from 'react-recompose'
 
-let GroupItem = FilterDragSource((props) => {
-  let {
-    child,
-    node,
-    index,
-    tree,
-    adding,
-    isRoot,
-    parent,
-    connectDragSource,
-    hover,
-  } = props
+let GroupItem = (props) => {
+  let { child, node, index, tree, adding, isRoot, parent, hover } = props
+  const [{ isDragging }, drag] = useFilterDragSource(props)
   let Component = child.children ? Group : Rule
-  return connectDragSource(
+  return (
     <div
+      ref={drag}
       style={{
         ...styles.dFlex,
         ...(index === node.children.length - 1 &&
           !F.view(adding) && { background }),
+        ...(isDragging && { opacity: 0.25 }),
       }}
     >
       {!(isRoot && node.children.length === 1) && (
@@ -42,7 +35,7 @@ let GroupItem = FilterDragSource((props) => {
       <Component {...props} node={child} parent={node} />
     </div>
   )
-})
+}
 
 // we need to observe this here and not on the export because Group is referenced elsewhere in the file
 let Group = _.flow(

--- a/packages/react/src/queryBuilder/Group.stories.js
+++ b/packages/react/src/queryBuilder/Group.stories.js
@@ -1,81 +1,98 @@
-import { root, DnDDecorator } from './stories/util.js'
+import { exampleTypes, mockService } from 'contexture-client'
+import ContextureMobx from '../utils/contexture-mobx.js'
+import { DnDDecorator } from './stories/util.js'
 import Component from './Group.js'
 
 export default {
   component: Component,
   decorators: [DnDDecorator],
   args: {
-    root,
     isRoot: true,
     adding: [false],
     hover: { wrap: [false], join: [''], remove: [false] },
   },
 }
 
+let Client = ContextureMobx({
+  debug: true,
+  types: exampleTypes,
+  service: mockService(),
+})
+
+const tree = Client({
+  key: 'root',
+  join: 'and',
+  children: [
+    { type: 'query', key: 'filter 1' },
+    {
+      key: 'group1',
+      join: 'or',
+      children: [
+        { type: 'query', key: 'filter 2a' },
+        { type: 'query', key: 'filter 2b' },
+        {
+          key: 'group2',
+          join: 'and',
+          children: [
+            {
+              key: 'filter 4a',
+              type: 'facet',
+            },
+            { type: 'query', key: 'filter 4b' },
+          ],
+        },
+      ],
+    },
+    { type: 'query', key: 'filter 3' },
+    {
+      key: 'group2',
+      join: 'not',
+      children: [
+        { key: 'filter 5a', type: 'number' },
+        { type: 'query', key: 'filter 5b' },
+      ],
+    },
+    {
+      key: 'group24',
+      join: 'or',
+      children: [
+        {
+          key: 'group2',
+          join: 'and',
+          children: [
+            { type: 'query', key: 'filter 4a' },
+            { key: 'txt filter 4b', type: 'text' },
+          ],
+        },
+        {
+          key: 'asdf',
+          typ: 'query',
+        },
+      ],
+    },
+    {
+      key: 'oneFilter',
+      join: 'or',
+      children: [
+        {
+          key: 'asdf',
+          typ: 'query',
+        },
+      ],
+    },
+  ],
+})
+
 export const OneFilter = {
   args: {
-    node: {
-      key: 'root',
-      join: 'and',
-      children: [{ key: 'filter 1', type: 'query' }],
-    },
+    tree,
+    node: tree.getNode(['root', 'oneFilter']),
   },
 }
 
 export const MultipleFilters = {
   args: {
-    node: {
-      key: 'root',
-      join: 'and',
-      children: [
-        { type: 'query', key: 'filter 1' },
-        {
-          key: 'group1',
-          join: 'or',
-          children: [
-            { type: 'query', key: 'filter 2a' },
-            { type: 'query', key: 'filter 2b' },
-            {
-              key: 'group2',
-              join: 'and',
-              children: [
-                {
-                  key: 'filter 4a',
-                  type: 'facet',
-                },
-                { type: 'query', key: 'filter 4b' },
-              ],
-            },
-          ],
-        },
-        { type: 'query', key: 'filter 3' },
-        {
-          key: 'group2',
-          join: 'not',
-          children: [
-            { key: 'filter 5a', type: 'number' },
-            { type: 'query', key: 'filter 5b' },
-          ],
-        },
-        {
-          key: 'group24',
-          join: 'or',
-          children: [
-            {
-              key: 'group2',
-              join: 'and',
-              children: [
-                { type: 'query', key: 'filter 4a' },
-                { key: 'txt filter 4b', type: 'text' },
-              ],
-            },
-            {
-              key: 'asdf',
-              typ: 'query',
-            },
-          ],
-        },
-      ],
-    },
+    tree,
+    node: tree.getNode(['root']),
   },
 }

--- a/packages/react/src/queryBuilder/Operator.stories.js
+++ b/packages/react/src/queryBuilder/Operator.stories.js
@@ -1,4 +1,4 @@
-import { parent, root, DnDDecorator } from './stories/util.js'
+import { parent, DnDDecorator } from './stories/util.js'
 import Component from './Operator.js'
 
 export default {
@@ -6,7 +6,6 @@ export default {
   decorators: [DnDDecorator],
   args: {
     index: 1,
-    root,
     parent,
     noDrop: true,
     child: { join: 'and' },

--- a/packages/react/src/queryBuilder/OperatorMenu.stories.js
+++ b/packages/react/src/queryBuilder/OperatorMenu.stories.js
@@ -1,4 +1,4 @@
-import { parent, root } from './stories/util.js'
+import { parent } from './stories/util.js'
 import Component from './OperatorMenu.js'
 
 export default {
@@ -6,7 +6,6 @@ export default {
   args: {
     node: { join: 'and' },
     parent,
-    root,
     hover: { wrap: [false], join: [''], remove: [false] },
   },
 }

--- a/packages/react/src/queryBuilder/QueryBuilder.js
+++ b/packages/react/src/queryBuilder/QueryBuilder.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import F from 'futil'
-import DDContext from './DragDrop/DDContext.js'
+import { DndProvider } from 'react-dnd'
+import { HTML5Backend } from 'react-dnd-html5-backend'
 import Group from './Group.js'
 import styles from '../styles/index.js'
 import { contexturifyWithoutLoader } from '../utils/hoc.js'
@@ -16,26 +17,26 @@ let QueryBuilder = ({
 }) => {
   let adding = React.useState(false)
   return (
-    <div style={{ background }}>
-      {node && (
-        <Group
-          isRoot={true}
-          {...{
-            node,
-            tree,
-            adding,
-            fields,
-            mapNodeToProps,
-          }}
-        />
-      )}
-      <Button onClick={F.flip(adding)}>
-        {F.view(adding) ? 'Cancel' : 'Add Filter'}
-      </Button>
-    </div>
+    <DndProvider backend={HTML5Backend}>
+      <div style={{ background }}>
+        {node && (
+          <Group
+            isRoot={true}
+            {...{
+              node,
+              tree,
+              adding,
+              fields,
+              mapNodeToProps,
+            }}
+          />
+        )}
+        <Button onClick={F.flip(adding)}>
+          {F.view(adding) ? 'Cancel' : 'Add Filter'}
+        </Button>
+      </div>
+    </DndProvider>
   )
 }
 
-export default DDContext(contexturifyWithoutLoader(QueryBuilder), {
-  allowEmptyNode: true,
-})
+export default contexturifyWithoutLoader(QueryBuilder)

--- a/packages/react/src/queryBuilder/Rule.js
+++ b/packages/react/src/queryBuilder/Rule.js
@@ -5,25 +5,19 @@ import F from 'futil'
 import styles from '../styles/index.js'
 import Indentable from './preview/Indentable.js'
 import FilterContents from './FilterContents.js'
-import FilterDragSource from './DragDrop/FilterDragSource.js'
+import useFilterDragSource from './DragDrop/FilterDragSource.js'
 import { oppositeJoin, indent } from '../utils/search.js'
 import { useLensObject } from '../utils/react.js'
 
-let Rule = ({
-  node,
-  parent,
-  tree,
-  connectDragSource,
-  isDragging,
-  ...props
-}) => {
+let Rule = ({ node, parent, tree, ...props }) => {
+  const [{ isDragging }, drag] = useFilterDragSource({ node, tree, ...props })
   let hover = useLensObject({
     indent: false,
     remove: false,
     rule: false,
   })
-  return connectDragSource(
-    <div style={styles.w100}>
+  return (
+    <div ref={drag} style={styles.w100}>
       <Indentable parent={parent} indent={hover.indent}>
         <div
           style={{
@@ -49,7 +43,7 @@ let Rule = ({
             <button
               {...F.domLens.hover(hover.indent)}
               style={{
-                color: styles.joinColor(oppositeJoin(parent.join)),
+                color: styles.joinColor(oppositeJoin(parent?.join)),
                 ...styles.btn,
                 ...styles.roundedRight0,
               }}
@@ -75,4 +69,4 @@ let Rule = ({
   )
 }
 
-export default _.flow(observer, FilterDragSource)(Rule)
+export default observer(Rule)

--- a/packages/react/src/queryBuilder/Rule.js
+++ b/packages/react/src/queryBuilder/Rule.js
@@ -1,6 +1,5 @@
 import React from 'react'
 import { observer } from 'mobx-react'
-import _ from 'lodash/fp.js'
 import F from 'futil'
 import styles from '../styles/index.js'
 import Indentable from './preview/Indentable.js'

--- a/packages/react/src/queryBuilder/Rule.stories.js
+++ b/packages/react/src/queryBuilder/Rule.stories.js
@@ -1,11 +1,10 @@
-import { root, DnDDecorator } from './stories/util.js'
+import { DnDDecorator } from './stories/util.js'
 import Component from './Rule.js'
 
 export default {
   component: Component,
   decorators: [DnDDecorator],
   args: {
-    root,
     node: { type: 'test', key: 'testKey' },
     tree: { join: 'and' },
     fields: {

--- a/packages/react/src/queryBuilder/stories/util.js
+++ b/packages/react/src/queryBuilder/stories/util.js
@@ -1,30 +1,17 @@
 import React from 'react'
 import F from 'futil'
+import { DndProvider } from 'react-dnd'
+import { HTML5Backend } from 'react-dnd-html5-backend'
 import { action } from '@storybook/addon-actions'
-import DDContext from '../DragDrop/DDContext.js'
 
-let DnDWrap = DDContext(({ children }) => <div>{children}</div>)
-
-export let DnDDecorator = (storyFn) => <DnDWrap>{storyFn()}</DnDWrap>
+export let DnDDecorator = (storyFn) => (
+  <DndProvider backend={HTML5Backend}>{storyFn()}</DndProvider>
+)
 
 export let parent = {
   lens: {
     wrapHover: F.objectLens(),
     removeHover: F.objectLens(),
     joinHover: F.objectLens(),
-  },
-}
-
-export let root = {
-  join: action('join'),
-  indent: action('indent'),
-  remove: action('remove'),
-  typeChange: action('typeChange'),
-  add: action('add'),
-  move: action('move'),
-  mutate: action('mutate'),
-  types: {
-    testType: {},
-    testType2: {},
   },
 }

--- a/packages/react/src/queryBuilder/stories/util.js
+++ b/packages/react/src/queryBuilder/stories/util.js
@@ -2,7 +2,6 @@ import React from 'react'
 import F from 'futil'
 import { DndProvider } from 'react-dnd'
 import { HTML5Backend } from 'react-dnd-html5-backend'
-import { action } from '@storybook/addon-actions'
 
 export let DnDDecorator = (storyFn) => (
   <DndProvider backend={HTML5Backend}>{storyFn()}</DndProvider>

--- a/packages/react/src/styles/generic.js
+++ b/packages/react/src/styles/generic.js
@@ -54,7 +54,7 @@ export let joinColor = (join) =>
     and: '#5bc0de',
     or: '#5cb85c',
     not: '#d9534f',
-  }[join.join || join])
+  }[join?.join || join])
 export let bgJoin = (tree) => ({
   background: joinColor(tree),
   color: 'white',

--- a/yarn.lock
+++ b/yarn.lock
@@ -1524,6 +1524,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/runtime@npm:^7.9.2":
+  version: 7.22.5
+  resolution: "@babel/runtime@npm:7.22.5"
+  dependencies:
+    regenerator-runtime: ^0.13.11
+  checksum: 12a50b7de2531beef38840d17af50c55a094253697600cee255311222390c68eed704829308d4fd305e1b3dfbce113272e428e9d9d45b1730e0fede997eaceb1
+  languageName: node
+  linkType: hard
+
 "@babel/template@npm:^7.18.10, @babel/template@npm:^7.20.7, @babel/template@npm:^7.3.3":
   version: 7.20.7
   resolution: "@babel/template@npm:7.20.7"
@@ -3179,6 +3188,27 @@ __metadata:
     webpack-plugin-serve:
       optional: true
   checksum: c45beded9c56fbbdc7213a2c36131ace5db360ed704d462cc39d6678f980173a91c9a3f691e6bd3a026f25486644cd0027e8a12a0a4eced8e8b886a0472e7d34
+  languageName: node
+  linkType: hard
+
+"@react-dnd/asap@npm:^5.0.1":
+  version: 5.0.2
+  resolution: "@react-dnd/asap@npm:5.0.2"
+  checksum: 18f040e53512983f11c542ef21e6e4cac605d585a10cd764b13bc1b2f3ac7490e0fa40503adc348d8387aa45bc8e7eebe9cb33003b960a30bb5fde666ff2adde
+  languageName: node
+  linkType: hard
+
+"@react-dnd/invariant@npm:^4.0.1":
+  version: 4.0.2
+  resolution: "@react-dnd/invariant@npm:4.0.2"
+  checksum: 594f6d78896c19bb8f023e101334fd91a9fdff686117bd8e830ba53737ec0a6042dab66971d3d63c7afbc622103909aff7a64c5c6767e0aa8d9561fd42705016
+  languageName: node
+  linkType: hard
+
+"@react-dnd/shallowequal@npm:^4.0.1":
+  version: 4.0.2
+  resolution: "@react-dnd/shallowequal@npm:4.0.2"
+  checksum: 7f21d691bddbfd4d2830948cbeefecca1600b2b46bcb1934926795f07ae8a1fa60a3dfd3a2112be5ef682c3820c80a99711e9fa15843f7e300acb25a4ecb70ab
   languageName: node
   linkType: hard
 
@@ -5309,13 +5339,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"asap@npm:^2.0.6":
-  version: 2.0.6
-  resolution: "asap@npm:2.0.6"
-  checksum: b296c92c4b969e973260e47523207cd5769abd27c245a68c26dc7a0fe8053c55bb04360237cb51cab1df52be939da77150ace99ad331fb7fb13b3423ed73ff3d
-  languageName: node
-  linkType: hard
-
 "assert@npm:^2.0.0":
   version: 2.0.0
   resolution: "assert@npm:2.0.0"
@@ -6529,8 +6552,8 @@ __metadata:
     prop-types: ^15.7.2
     react: ^16.8.0
     react-date-picker: ^7.2.0
-    react-dnd: ^2.5.4
-    react-dnd-html5-backend: ^2.5.4
+    react-dnd: ^16.0.1
+    react-dnd-html5-backend: ^16.0.1
     react-dom: ^16.8.0
     react-measure: ^2.3.0
     react-recompose: ^0.31.2
@@ -7150,22 +7173,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"disposables@npm:^1.0.1":
-  version: 1.0.2
-  resolution: "disposables@npm:1.0.2"
-  checksum: a3b295098985c4911f2084f36175161e3d9d2f420bd58bac7b34118681aeae3e09d91568a0d75ac80072499c750c9cfe62b244a873c5f95e006f138ef27c5f01
-  languageName: node
-  linkType: hard
-
-"dnd-core@npm:^2.6.0":
-  version: 2.6.0
-  resolution: "dnd-core@npm:2.6.0"
+"dnd-core@npm:^16.0.1":
+  version: 16.0.1
+  resolution: "dnd-core@npm:16.0.1"
   dependencies:
-    asap: ^2.0.6
-    invariant: ^2.0.0
-    lodash: ^4.2.0
-    redux: ^3.7.1
-  checksum: 4b64a05e3f11ce2552929ee2c90d3158b817c11989de599c1ab6f44849a26e2436a990bc0d45a3657fcf2a646fefc74313c80203b1a2f01e56835cb72810a6c8
+    "@react-dnd/asap": ^5.0.1
+    "@react-dnd/invariant": ^4.0.1
+    redux: ^4.2.0
+  checksum: b7d3ef4664f433af796f440ddd27ad9d7fef0205f26c4b7c0af6ebf612ffa9b33e64d095d3e79190c4baaed34aa36570f321ebe0d2cc8ff1031ff158a0907b3f
   languageName: node
   linkType: hard
 
@@ -9164,7 +9179,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"hoist-non-react-statics@npm:^2.1.0, hoist-non-react-statics@npm:^2.5.5":
+"hoist-non-react-statics@npm:^2.5.5":
   version: 2.5.5
   resolution: "hoist-non-react-statics@npm:2.5.5"
   checksum: ee2d05e5c7e1398ad84a15b0327f66bd78f38a8e0015e852f954b36434e32eb7e942d5357505020a3a1147f247b165bf1e69d72393e3accab67cafdafeb86230
@@ -9489,15 +9504,6 @@ __metadata:
   version: 1.4.0
   resolution: "interpret@npm:1.4.0"
   checksum: 2e5f51268b5941e4a17e4ef0575bc91ed0ab5f8515e3cf77486f7c14d13f3010df9c0959f37063dcc96e78d12dc6b0bb1b9e111cdfe69771f4656d2993d36155
-  languageName: node
-  linkType: hard
-
-"invariant@npm:^2.0.0, invariant@npm:^2.1.0":
-  version: 2.2.4
-  resolution: "invariant@npm:2.2.4"
-  dependencies:
-    loose-envify: ^1.0.0
-  checksum: cc3182d793aad82a8d1f0af697b462939cb46066ec48bbf1707c150ad5fad6406137e91a262022c269702e01621f35ef60269f6c0d7fd178487959809acdfb14
   languageName: node
   linkType: hard
 
@@ -10965,13 +10971,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash-es@npm:^4.2.1":
-  version: 4.17.21
-  resolution: "lodash-es@npm:4.17.21"
-  checksum: 05cbffad6e2adbb331a4e16fbd826e7faee403a1a04873b82b42c0f22090f280839f85b95393f487c1303c8a3d2a010048bf06151a6cbe03eee4d388fb0a12d2
-  languageName: node
-  linkType: hard
-
 "lodash.debounce@npm:^4.0.8":
   version: 4.0.8
   resolution: "lodash.debounce@npm:4.0.8"
@@ -11042,14 +11041,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash@npm:^4.17.11, lodash@npm:^4.17.15, lodash@npm:^4.17.20, lodash@npm:^4.17.21, lodash@npm:^4.17.4, lodash@npm:^4.2.0, lodash@npm:^4.2.1":
+"lodash@npm:^4.17.11, lodash@npm:^4.17.15, lodash@npm:^4.17.20, lodash@npm:^4.17.21, lodash@npm:^4.17.4":
   version: 4.17.21
   resolution: "lodash@npm:4.17.21"
   checksum: eb835a2e51d381e561e508ce932ea50a8e5a68f4ebdd771ea240d3048244a8d13658acbd502cd4829768c56f2e16bdd4340b9ea141297d472517b83868e677f7
   languageName: node
   linkType: hard
 
-"loose-envify@npm:^1.0.0, loose-envify@npm:^1.1.0, loose-envify@npm:^1.4.0":
+"loose-envify@npm:^1.1.0, loose-envify@npm:^1.4.0":
   version: 1.4.0
   resolution: "loose-envify@npm:1.4.0"
   dependencies:
@@ -12823,7 +12822,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prop-types@npm:^15.5.10, prop-types@npm:^15.5.8, prop-types@npm:^15.6.0, prop-types@npm:^15.6.1, prop-types@npm:^15.6.2, prop-types@npm:^15.7.2, prop-types@npm:^15.8.1":
+"prop-types@npm:^15.5.8, prop-types@npm:^15.6.0, prop-types@npm:^15.6.1, prop-types@npm:^15.6.2, prop-types@npm:^15.7.2, prop-types@npm:^15.8.1":
   version: 15.8.1
   resolution: "prop-types@npm:15.8.1"
   dependencies:
@@ -13061,28 +13060,37 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-dnd-html5-backend@npm:^2.5.4":
-  version: 2.6.0
-  resolution: "react-dnd-html5-backend@npm:2.6.0"
+"react-dnd-html5-backend@npm:^16.0.1":
+  version: 16.0.1
+  resolution: "react-dnd-html5-backend@npm:16.0.1"
   dependencies:
-    lodash: ^4.2.0
-  checksum: 5c18d6bde6d078e96f409ae9639fb112fb5fab9596f28824036a612ade16b66c40450873aaca68e8cd9f65eaeed6089e3e8e02629240e03451ea2a3ee937ff9d
+    dnd-core: ^16.0.1
+  checksum: e2368bf85d5632a5cd867b743feb54c9052d909ea5331608860fa455edf3c633ac791f5b338e3db29b19ea8670c0ba5fb43c9c1c2510760bea030811d726cdfa
   languageName: node
   linkType: hard
 
-"react-dnd@npm:^2.5.4":
-  version: 2.6.0
-  resolution: "react-dnd@npm:2.6.0"
+"react-dnd@npm:^16.0.1":
+  version: 16.0.1
+  resolution: "react-dnd@npm:16.0.1"
   dependencies:
-    disposables: ^1.0.1
-    dnd-core: ^2.6.0
-    hoist-non-react-statics: ^2.1.0
-    invariant: ^2.1.0
-    lodash: ^4.2.0
-    prop-types: ^15.5.10
+    "@react-dnd/invariant": ^4.0.1
+    "@react-dnd/shallowequal": ^4.0.1
+    dnd-core: ^16.0.1
+    fast-deep-equal: ^3.1.3
+    hoist-non-react-statics: ^3.3.2
   peerDependencies:
-    react: "*"
-  checksum: f35add1fab5dc5ddc5f5d7535b6d6add04cf0bcfd9502a1d3e7a35eb717ac18a66eb08a7317b180713c1a22e3375340b760fb06fbb8228cb3f404bff50917b48
+    "@types/hoist-non-react-statics": ">= 3.3.1"
+    "@types/node": ">= 12"
+    "@types/react": ">= 16"
+    react: ">= 16.14"
+  peerDependenciesMeta:
+    "@types/hoist-non-react-statics":
+      optional: true
+    "@types/node":
+      optional: true
+    "@types/react":
+      optional: true
+  checksum: e8da2186aaafcd5bb41c090a995c963a7c3c73c20991667a2cfc0c800d7f7f73913414b2e61c437cdb6221bb2151bd5174088b8b42c17056a896fc4d1da5729f
   languageName: node
   linkType: hard
 
@@ -13468,15 +13476,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"redux@npm:^3.7.1":
-  version: 3.7.2
-  resolution: "redux@npm:3.7.2"
+"redux@npm:^4.2.0":
+  version: 4.2.1
+  resolution: "redux@npm:4.2.1"
   dependencies:
-    lodash: ^4.2.1
-    lodash-es: ^4.2.1
-    loose-envify: ^1.1.0
-    symbol-observable: ^1.0.3
-  checksum: c349b77e68d009bc530d3cb6252a6a3e43e20a6e52f9483a048b24cd2f266d9bfa6f0bbd4769d40fe36795e2f7a7a884c3ddc92c13e82efd3328890f94821091
+    "@babel/runtime": ^7.9.2
+  checksum: f63b9060c3a1d930ae775252bb6e579b42415aee7a23c4114e21a0b4ba7ec12f0ec76936c00f546893f06e139819f0e2855e0d55ebfce34ca9c026241a6950dd
   languageName: node
   linkType: hard
 
@@ -14574,7 +14579,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"symbol-observable@npm:^1.0.3, symbol-observable@npm:^1.2.0":
+"symbol-observable@npm:^1.2.0":
   version: 1.2.0
   resolution: "symbol-observable@npm:1.2.0"
   checksum: 48ffbc22e3d75f9853b3ff2ae94a44d84f386415110aea5effc24d84c502e03a4a6b7a8f75ebaf7b585780bda34eb5d6da3121f826a6f93398429d30032971b6


### PR DESCRIPTION
We're using a very outdated version of react-dnd which is distributed as commonjs only. This PR upgrades it so we can use it with modern bundlers.