### PR TITLE
PR Feedback for UI of Keyword Generations

### DIFF
--- a/.changeset/four-jobs-own.md
+++ b/.changeset/four-jobs-own.md
@@ -1,0 +1,5 @@
+---
+'contexture-react': patch
+---
+
+Update UI of keyword generations..

--- a/packages/react/src/exampleTypes/ExpandableTagsQuery/KeywordGenerations.js
+++ b/packages/react/src/exampleTypes/ExpandableTagsQuery/KeywordGenerations.js
@@ -101,7 +101,7 @@ let KeywordGenerations = ({
         <span
           style={{
             fontFamily: 'Lato',
-            fontSize: '9px',
+            fontSize: '12px',
             fontWeight: 'normal',
             fontStretch: 'normal',
             fontStyle: 'italic',

--- a/packages/react/src/exampleTypes/ExpandableTagsQuery/index.js
+++ b/packages/react/src/exampleTypes/ExpandableTagsQuery/index.js
@@ -21,8 +21,7 @@ import KeywordGenerations from './KeywordGenerations.js'
 
 let innerHeightLimit = 40
 
-let isKeywordLightBulbOn = (tags) => 
-  sanitizeTagInputs(tags)?.length > 2 
+let isKeywordLightBulbOn = (tags) => sanitizeTagInputs(tags)?.length > 2
 
 let triggerKeywordGeneration = async (node, tree) => {
   await tree.mutate(node.path, { generateKeywords: true })
@@ -228,24 +227,26 @@ let TagsWrapper = observer(
                 {
                   width: 35,
                   strokeOpacity: 0.5,
-                  ...(!enableKeywordGenerations && {display : 'none'}),
-                  ...(isKeywordLightBulbOn(node.tags) && {strokeOpacity: 1.0}),
+                  ...(!enableKeywordGenerations && { display: 'none' }),
+                  ...(isKeywordLightBulbOn(node.tags) && {
+                    strokeOpacity: 1.0,
+                  }),
                 }
               }
               onClick={async () => {
                 // Generate keywords or show existing keywords
-                if ( !node.generateKeywords && isKeywordLightBulbOn(node.tags) ) 
-                {
+                if (!node.generateKeywords && isKeywordLightBulbOn(node.tags)) {
                   // Store to operate on this after showing keyword section,
                   // so that the loading indicator is shown while generating keywords
                   let collapsedState = F.view(generationsCollapsed)
                   let context = toJS(node.context)
                   F.off(generationsCollapsed)()
                   if (
-                    !collapsedState || _.isEmpty(context.keywordGenerations) ||
+                    !collapsedState ||
+                    _.isEmpty(context.keywordGenerations) ||
                     _.isEmpty(
                       _.difference(
-                        _.keys(context.keywordGenerations), 
+                        _.keys(context.keywordGenerations),
                         _.keys(context.tags)
                       )
                     )

--- a/packages/react/src/exampleTypes/ExpandableTagsQuery/index.js
+++ b/packages/react/src/exampleTypes/ExpandableTagsQuery/index.js
@@ -21,6 +21,9 @@ import KeywordGenerations from './KeywordGenerations.js'
 
 let innerHeightLimit = 40
 
+let isKeywordLightBulbOn = (tags) => 
+  sanitizeTagInputs(tags)?.length > 2 
+
 let triggerKeywordGeneration = async (node, tree) => {
   await tree.mutate(node.path, { generateKeywords: true })
   tree.mutate(node.path, { generateKeywords: false })
@@ -98,7 +101,7 @@ let ExpandableTagsQuery = ({
       {!F.view(generationsCollapsed) && (
         <hr
           style={{
-            border: '2px solid #EBEBEB',
+            border: '1px solid #EBEBEB',
             ...(!_.isEmpty(innerEdgeMargins) && { marginLeft, marginRight }),
             ...(!F.view(collapse) && { marginBottom: '10px' }),
             ...(showMoreKeywordsButton && { marginBottom: 20 }),
@@ -222,21 +225,30 @@ let TagsWrapper = observer(
               style={
                 // Show suggestion lightbulb if min of 3 non numeric tags exist,
                 // including numbers ups the chance of producing bad suggestions
-                sanitizeTagInputs(node.tags)?.length > 2 &&
-                enableKeywordGenerations
-                  ? { width: 35, strokeOpacity: 1 }
-                  : { width: 35, strokeOpacity: 0.5 }
+                {
+                  width: 35,
+                  strokeOpacity: 0.5,
+                  ...(!enableKeywordGenerations && {display : 'none'}),
+                  ...(isKeywordLightBulbOn(node.tags) && {strokeOpacity: 1.0}),
+                }
               }
               onClick={async () => {
                 // Generate keywords or show existing keywords
-                if (!node.generateKeywords) {
+                if ( !node.generateKeywords && isKeywordLightBulbOn(node.tags) ) 
+                {
                   // Store to operate on this after showing keyword section,
                   // so that the loading indicator is shown while generating keywords
                   let collapsedState = F.view(generationsCollapsed)
+                  let context = toJS(node.context)
                   F.off(generationsCollapsed)()
                   if (
-                    !collapsedState ||
-                    _.isEmpty(toJS(node.context.keywordGenerations))
+                    !collapsedState || _.isEmpty(context.keywordGenerations) ||
+                    _.isEmpty(
+                      _.difference(
+                        _.keys(context.keywordGenerations), 
+                        _.keys(context.tags)
+                      )
+                    )
                   ) {
                     await triggerKeywordGeneration(node, tree)
                   }
@@ -245,10 +257,7 @@ let TagsWrapper = observer(
             >
               <KeywordGenerationIcon
                 strokeColor={
-                  sanitizeTagInputs(node.tags)?.length > 2 &&
-                  enableKeywordGenerations
-                    ? 'rgb(92, 184, 92)'
-                    : 'currentColor'
+                  isKeywordLightBulbOn(node.tags) ? '#0076de' : 'currentColor'
                 }
               />
             </TextButton>


### PR DESCRIPTION
## Summary 
Updates to UI and workflow of keyword generations. This corrects and edge case in which if a user adds all of the keywords and re-opens them it was still showing a blank list as the cached list should show. In the case where  we show a cached list that is included fully within the tags being searched new keywords are retrieved now. 

Some other updates to visual elements of the UI where made based on Robert's feedback when looking through the UI updates. 