### PR TITLE
Fix keyword counts past 100 showing 0 

### DIFF
--- a/.changeset/stupid-jeans-approve.md
+++ b/.changeset/stupid-jeans-approve.md
@@ -1,0 +1,6 @@
+---
+'contexture-elasticsearch': patch
+'contexture-react': patch
+---
+
+Fix keyword count when past the limit to retrieve counts.

--- a/packages/provider-elasticsearch/src/example-types/filters/tagsQuery.js
+++ b/packages/provider-elasticsearch/src/example-types/filters/tagsQuery.js
@@ -133,17 +133,17 @@ let result = (generateKeywords) => async (node, search) => {
       sanitizeTagInputs(node.tags)
     )
   )
-    
+
   let result = await search(aggs)
 
   return {
-    tags: _.mapValues('doc_count',result.aggregations.tags.buckets),
+    tags: _.mapValues('doc_count', result.aggregations.tags.buckets),
     ...(result.aggregations.keywordGenerations && {
       keywordGenerations: compactMapValues(
         'doc_count',
         result.aggregations.keywordGenerations.buckets
       ),
-    })
+    }),
   }
 }
 

--- a/packages/provider-elasticsearch/src/example-types/filters/tagsQuery.js
+++ b/packages/provider-elasticsearch/src/example-types/filters/tagsQuery.js
@@ -133,11 +133,18 @@ let result = (generateKeywords) => async (node, search) => {
       sanitizeTagInputs(node.tags)
     )
   )
+    
+  let result = await search(aggs)
 
-  return _.mapValues(
-    (prop) => compactMapValues('doc_count', prop.buckets),
-    (await search(aggs)).aggregations
-  )
+  return {
+    tags: _.mapValues('doc_count',result.aggregations.tags.buckets),
+    ...(result.aggregations.keywordGenerations && {
+      keywordGenerations: compactMapValues(
+        'doc_count',
+        result.aggregations.keywordGenerations.buckets
+      ),
+    })
+  }
 }
 
 let validContext = (node) => {

--- a/packages/react/src/exampleTypes/ExpandableTagsQuery/KeywordGenerations.js
+++ b/packages/react/src/exampleTypes/ExpandableTagsQuery/KeywordGenerations.js
@@ -40,10 +40,10 @@ let KeywordGenerations = ({
   return (
     <div style={!F.view(generationsCollapsed) ? {} : { display: 'none' }}>
       <div>
-        {node.isStale && node.generateKeywords && (
-          <Loader style={{ textAlign: 'center' }} loading={true}>
-            Loading...
-          </Loader>
+        {node.isStale && node.generateKeywords && _.size(node.tags) <= 100 && (
+            <Loader style={{ textAlign: 'center' }} loading={true}>
+              Loading...
+            </Loader>
         )}
         {!node.generateKeywords &&
           _.map((word) => (
@@ -75,6 +75,9 @@ let KeywordGenerations = ({
               keysToLower(node.context?.keywordGenerations)
             )
           )}
+          {_.size(node.tags) > 100 && _.size(node.context?.keywordGenerations) === 0 && (
+            'Keyword suggestions are limited once 100 or more keywords are present, please remove some keywords to generate suggestions.'
+            )}
       </div>
       <div
         style={{

--- a/packages/react/src/exampleTypes/ExpandableTagsQuery/KeywordGenerations.js
+++ b/packages/react/src/exampleTypes/ExpandableTagsQuery/KeywordGenerations.js
@@ -41,9 +41,9 @@ let KeywordGenerations = ({
     <div style={!F.view(generationsCollapsed) ? {} : { display: 'none' }}>
       <div>
         {node.isStale && node.generateKeywords && _.size(node.tags) <= 100 && (
-            <Loader style={{ textAlign: 'center' }} loading={true}>
-              Loading...
-            </Loader>
+          <Loader style={{ textAlign: 'center' }} loading={true}>
+            Loading...
+          </Loader>
         )}
         {!node.generateKeywords &&
           _.map((word) => (
@@ -75,9 +75,9 @@ let KeywordGenerations = ({
               keysToLower(node.context?.keywordGenerations)
             )
           )}
-          {_.size(node.tags) > 100 && _.size(node.context?.keywordGenerations) === 0 && (
-            'Keyword suggestions are limited once 100 or more keywords are present, please remove some keywords to generate suggestions.'
-            )}
+        {_.size(node.tags) > 100 &&
+          _.size(node.context?.keywordGenerations) === 0 &&
+          'Keyword suggestions are limited once 100 or more keywords are present, please remove some keywords to generate suggestions.'}
       </div>
       <div
         style={{

--- a/packages/react/src/exampleTypes/ExpandableTagsQuery/index.js
+++ b/packages/react/src/exampleTypes/ExpandableTagsQuery/index.js
@@ -149,7 +149,13 @@ let TagsWrapper = observer(
             `context.keywordGenerations.${props.value}`,
           ],
           node,
-          node.forceFilterOnly ? undefined : 0
+          node.forceFilterOnly || node.updating ? 
+            undefined : 
+            F.when(
+              _.isNaN(), 
+              undefined, 
+              _.get(`context.tags.${props.value}`, node)
+            )
         )
         let tagProps = {
           ...props,

--- a/packages/react/src/exampleTypes/ExpandableTagsQuery/index.js
+++ b/packages/react/src/exampleTypes/ExpandableTagsQuery/index.js
@@ -149,13 +149,13 @@ let TagsWrapper = observer(
             `context.keywordGenerations.${props.value}`,
           ],
           node,
-          node.forceFilterOnly || node.updating ? 
-            undefined : 
-            F.when(
-              _.isNaN(), 
-              undefined, 
-              _.get(`context.tags.${props.value}`, node)
-            )
+          node.forceFilterOnly || node.updating
+            ? undefined
+            : F.when(
+                _.isNaN(),
+                undefined,
+                _.get(`context.tags.${props.value}`, node)
+              )
         )
         let tagProps = {
           ...props,


### PR DESCRIPTION
## Summary 
Keyword counts now populate 0, if 0 is the count in the results of contexture. This prevents faulty counts based on zero result keywords as well as allowing to discern between undefined instances and 0 instances of keywords. 

Keyword suggestions have also been updated as when we cannot retrieve counts the keyword suggestions would provide a lot of non relevant suggestions, as such a proper message is provided to the user to understand why nothing is generated and how to correct the problem. 