### PR TITLE
fix(client/pivot): expand returning promise

### DIFF
--- a/.changeset/spicy-elephants-shop.md
+++ b/.changeset/spicy-elephants-shop.md
@@ -1,0 +1,5 @@
+---
+'contexture-client': patch
+---
+
+client/pivot: expand method is returning promise

--- a/packages/client/src/exampleTypes/pivot.js
+++ b/packages/client/src/exampleTypes/pivot.js
@@ -123,7 +123,7 @@ export default {
         maybeAddRootExpansion(n, 'columns')
         maybeAddRootExpansion(n, 'rows')
 
-        mutate(path, {
+        return mutate(path, {
           expansions: [
             ...n.expansions,
             {

--- a/packages/client/src/index.test.js
+++ b/packages/client/src/index.test.js
@@ -2435,7 +2435,9 @@ let AllTests = (ContextureClient) => {
     })
 
     let node = Tree.getNode(['root', 'pivot'])
-    node.expand('rows', ['Florida'])
+    let expandPromise = node.expand('rows', ['Florida'])
+
+    expect(expandPromise instanceof Promise).toBe(true)
 
     expect(toJS(Tree.getNode(['root', 'pivot']).expansions)).toEqual([
       { type: 'columns', drilldown: [], loaded: [] },

--- a/packages/client/src/index.test.js
+++ b/packages/client/src/index.test.js
@@ -2437,7 +2437,7 @@ let AllTests = (ContextureClient) => {
     let node = Tree.getNode(['root', 'pivot'])
     let expandPromise = node.expand('rows', ['Florida'])
 
-    expect(expandPromise instanceof Promise).toBe(true)
+    expect(typeof expandPromise.then).toBe('function')
 
     expect(toJS(Tree.getNode(['root', 'pivot']).expansions)).toEqual([
       { type: 'columns', drilldown: [], loaded: [] },


### PR DESCRIPTION
* [x] client: expand on pivot node now returns the dispatch promise