### PR TITLE
ES pivot: `groupCounts` and `skip` configuration

### DIFF
--- a/.changeset/strange-plants-pull.md
+++ b/.changeset/strange-plants-pull.md
@@ -2,4 +2,4 @@
 'contexture-elasticsearch': minor
 ---
 
-Pivot: configuring `groupCounts` and `skip` per group/value level. `groupCounts` flag adds subgroups counter to the parent level. `skip` flag skips the groping level in aggregation 
+Pivot: configuring `groupCounts` and `skip` per group/value level. `groupCounts` flag adds subgroups counter to the parent level. `skip` flag skips the groping level in aggregation

--- a/.changeset/strange-plants-pull.md
+++ b/.changeset/strange-plants-pull.md
@@ -2,4 +2,4 @@
 'contexture-elasticsearch': minor
 ---
 
-Pivot: configuring `groupCounts` and `skip` per group/value level. `groupCounts` flag adds subgroups counter to parent level. `skip` flag skips the groping level in aggregation
+Pivot: configuring `groupCounts` and `skip` per group/value level. `groupCounts` flag adds subgroups counter to the parent level. `skip` flag skips the groping level in aggregation 

--- a/.changeset/strange-plants-pull.md
+++ b/.changeset/strange-plants-pull.md
@@ -2,4 +2,4 @@
 'contexture-elasticsearch': minor
 ---
 
-Pivot: configuring `groupCounts` and `skip` per group/value level
+Pivot: configuring `groupCounts` and `skip` per group/value level. `groupCounts` flag adds subgroups counter to parent level. `skip` flag skips the groping level in aggregation 

--- a/.changeset/strange-plants-pull.md
+++ b/.changeset/strange-plants-pull.md
@@ -2,4 +2,4 @@
 'contexture-elasticsearch': minor
 ---
 
-Pivot: configuring `groupCounts` and `skip` per group/value level. `groupCounts` flag adds subgroups counter to parent level. `skip` flag skips the groping level in aggregation 
+Pivot: configuring `groupCounts` and `skip` per group/value level. `groupCounts` flag adds subgroups counter to parent level. `skip` flag skips the groping level in aggregation

--- a/.changeset/strange-plants-pull.md
+++ b/.changeset/strange-plants-pull.md
@@ -1,0 +1,5 @@
+---
+'contexture-elasticsearch': minor
+---
+
+Pivot: configuring `groupCounts` and `skip` per group/value level

--- a/packages/provider-elasticsearch/README.md
+++ b/packages/provider-elasticsearch/README.md
@@ -373,8 +373,8 @@ All of these types share a similar output structure. Results are on a context pr
 Supports nested groupings of `xGroupStats`
 | Name | Type | Default | Description |
 | ---- | ---- | ------- | ----------- |
-| `groups` | object[] | None, _required_ | Groupings to apply, can be any `xGroupStat` type |
-| `values` | object[] | None | Metric values to compute, includes `field`, `type`, and potentially type specific fields. Type can be avg, min, max, sum, or any of the other metrics supported by elasticsearch |
+| `columns` `rows` | object[] | None | Column and row groupings to apply. Includes `field` can be any `xGroupStat` `type`. `groupCounts` adds subgroups counter to parent level. `skip` skips the groping level in aggregation |
+| `values` | object[] | None | Metric values to compute, includes `field`, `type`, and potentially type specific fields. Type can be avg, min, max, sum, or any of the other metrics supported by elasticsearch. `skip` skips the value in stat aggregation |
 | `drilldown` | [string] | None | Drills down results where each entry of the array corresponds to a key from a grouping to allow progresive "drilldown"/"zooming" of groups. If a drilldown is specified, it will exclude nested groups > 1 deeper (e.g. `['a']` will filter the first group to `a` and expand the second, `[]` will only include the root group). Passing a falsey value will include all groups |
 | `sort` | object[] | None | `{ columnValues, valueIndex, valueProp, direction }` |
 | `sort.columnValues` | [string/number] | None | Values of columns to sort by, e.g. [2017, 'Q1']. If null, it will sort by the root level values. |

--- a/packages/provider-elasticsearch/README.md
+++ b/packages/provider-elasticsearch/README.md
@@ -373,8 +373,8 @@ All of these types share a similar output structure. Results are on a context pr
 Supports nested groupings of `xGroupStats`
 | Name | Type | Default | Description |
 | ---- | ---- | ------- | ----------- |
-| `columns` `rows` | object[] | None | Column and row groupings to apply. Includes `field` can be any `xGroupStat` `type`. `groupCounts` adds subgroups counter to parent level. `skip` skips the groping level in aggregation |
-| `values` | object[] | None | Metric values to compute, includes `field`, `type`, and potentially type specific fields. Type can be avg, min, max, sum, or any of the other metrics supported by elasticsearch. `skip` skips the value in stat aggregation |
+| `columns` `rows` | object[] | None | Column and row groupings to apply. Includes `field`, `type` can be any of `xGroupStat` . `groupCounts` adds subgroups counter to the parent level. `skip` skips the groping level in the aggregation query |
+| `values` | object[] | None | Metric values to compute, includes `field`, `type`, and potentially type specific fields. Type can be avg, min, max, sum, or any of the other metrics supported by elasticsearch. `skip` skips the value in stat aggregation query |
 | `drilldown` | [string] | None | Drills down results where each entry of the array corresponds to a key from a grouping to allow progresive "drilldown"/"zooming" of groups. If a drilldown is specified, it will exclude nested groups > 1 deeper (e.g. `['a']` will filter the first group to `a` and expand the second, `[]` will only include the root group). Passing a falsey value will include all groups |
 | `sort` | object[] | None | `{ columnValues, valueIndex, valueProp, direction }` |
 | `sort.columnValues` | [string/number] | None | Values of columns to sort by, e.g. [2017, 'Q1']. If null, it will sort by the root level values. |

--- a/packages/provider-elasticsearch/README.md
+++ b/packages/provider-elasticsearch/README.md
@@ -374,7 +374,7 @@ Supports nested groupings of `xGroupStats`
 | Name | Type | Default | Description |
 | ---- | ---- | ------- | ----------- |
 | `columns` `rows` | object[] | None | Column and row groupings to apply. Includes `field`, `type` can be any of `xGroupStat` . `groupCounts` adds subgroups counter to the parent level. `skip` skips the groping level in the aggregation query |
-| `values` | object[] | None | Metric values to compute, includes `field`, `type`, and potentially type specific fields. Type can be avg, min, max, sum, or any of the other metrics supported by elasticsearch. `skip` skips the value in stat aggregation query |
+| `values` | object[] | None | Metric values to compute, includes `field`, `type`, and potentially type specific fields. Type can be avg, min, max, sum, or any of the other metrics supported by elasticsearch. `skip` skips the value in the aggregation query |
 | `drilldown` | [string] | None | Drills down results where each entry of the array corresponds to a key from a grouping to allow progresive "drilldown"/"zooming" of groups. If a drilldown is specified, it will exclude nested groups > 1 deeper (e.g. `['a']` will filter the first group to `a` and expand the second, `[]` will only include the root group). Passing a falsey value will include all groups |
 | `sort` | object[] | None | `{ columnValues, valueIndex, valueProp, direction }` |
 | `sort.columnValues` | [string/number] | None | Values of columns to sort by, e.g. [2017, 'Q1']. If null, it will sort by the root level values. |

--- a/packages/provider-elasticsearch/src/example-types/metricGroups/fieldValuesGroupStats.js
+++ b/packages/provider-elasticsearch/src/example-types/metricGroups/fieldValuesGroupStats.js
@@ -64,10 +64,24 @@ let buildGroupQueryWithDefaultSortField = (node, ...args) =>
 
 let getGroups = (aggs) => (aggs.valueFilter || aggs).groups.buckets
 
+let addGroupCount = (query, group, type, schema) =>
+  _.merge(query, {
+    aggs: {
+      [`${type}GroupCount`]: {
+        cardinality: {
+          field: getField(schema, group.field),
+          precision_threshold: 100, // less load on ES
+        },
+      },
+    },
+  })
+
+
 // We don't want the default sort field for pivot, but we do for this node type
 export default {
   ...groupStats(buildGroupQueryWithDefaultSortField),
   buildGroupQuery,
   getGroups,
   drilldown,
+  addGroupCount,
 }

--- a/packages/provider-elasticsearch/src/example-types/metricGroups/fieldValuesGroupStats.js
+++ b/packages/provider-elasticsearch/src/example-types/metricGroups/fieldValuesGroupStats.js
@@ -76,7 +76,6 @@ let addGroupCount = (query, group, type, schema) =>
     },
   })
 
-
 // We don't want the default sort field for pivot, but we do for this node type
 export default {
   ...groupStats(buildGroupQueryWithDefaultSortField),

--- a/packages/provider-elasticsearch/src/example-types/metricGroups/pivot.js
+++ b/packages/provider-elasticsearch/src/example-types/metricGroups/pivot.js
@@ -290,7 +290,7 @@ let createPivotScope = (node, schema, getStats) => {
           group.sort = { field: sortField, direction: sort.direction }
         }
         let build = lookupTypeProp(
-          _.rearg([1], _.identity),
+          () => F.throws(Error('Unknown grouping type')),
           'buildGroupQuery',
           group.type
         )

--- a/packages/provider-elasticsearch/src/example-types/metricGroups/pivot.js
+++ b/packages/provider-elasticsearch/src/example-types/metricGroups/pivot.js
@@ -290,7 +290,7 @@ let createPivotScope = (node, schema, getStats) => {
           group.sort = { field: sortField, direction: sort.direction }
         }
         let build = lookupTypeProp(
-          () => F.throws(Error('Unknown grouping type')),
+          () => F.throws(Error(`Unknown pivot grouping type: ${group.type}`)),
           'buildGroupQuery',
           group.type
         )

--- a/packages/provider-elasticsearch/src/example-types/metricGroups/pivot.js
+++ b/packages/provider-elasticsearch/src/example-types/metricGroups/pivot.js
@@ -289,7 +289,11 @@ let createPivotScope = (node, schema, getStats) => {
           // The API of `{sort: {field, direction}}` is respected by fieldValues and can be added to others
           group.sort = { field: sortField, direction: sort.direction }
         }
-        let build = lookupTypeProp(_.rearg([1], _.identity), 'buildGroupQuery', group.type)
+        let build = lookupTypeProp(
+          _.rearg([1], _.identity),
+          'buildGroupQuery',
+          group.type
+        )
         // We are iterating through the groups reversed, so we need to subtract instead of add to get the right index
         let groupIndex = groups.length - reversedIndex - 1
         let drilldownKey = _.get(
@@ -309,7 +313,11 @@ let createPivotScope = (node, schema, getStats) => {
             )
 
         if (group.groupCounts) {
-          let addGroupCount = lookupTypeProp(_.identity, 'addGroupCount', group.type)
+          let addGroupCount = lookupTypeProp(
+            _.identity,
+            'addGroupCount',
+            group.type
+          )
           parent = addGroupCount(parent, group, groupingType, schema)
         }
 
@@ -370,7 +378,9 @@ let createPivotScope = (node, schema, getStats) => {
     })
 
     let aggValues = _.reject('skip', node.values)
-    let statsAggs = _.isEmpty(aggValues) ? {} : { aggs: getAggsForValues(aggValues) }
+    let statsAggs = _.isEmpty(aggValues)
+      ? {}
+      : { aggs: getAggsForValues(aggValues) }
 
     if (!_.isEmpty(columns)) {
       let columnsStatsAggs = await buildNestedGroupQuery(

--- a/packages/provider-elasticsearch/test/example-types/metricGroups/pivot.test.js
+++ b/packages/provider-elasticsearch/test/example-types/metricGroups/pivot.test.js
@@ -2805,7 +2805,12 @@ describe('pivot', () => {
       ],
       columns: [
         { type: 'dateInterval', field: 'PO.IssuedDate', interval: 'year' },
-        { type: 'dateInterval', field: 'PO.IssuedDate', interval: 'month', skip: true },
+        {
+          type: 'dateInterval',
+          field: 'PO.IssuedDate',
+          interval: 'month',
+          skip: true,
+        },
       ],
       expanded: { columns: true, rows: true, skipValues: true },
     }
@@ -2813,28 +2818,28 @@ describe('pivot', () => {
       aggs: {
         columns: {
           date_histogram: {
-            field: "PO.IssuedDate",
-            calendar_interval: "year",
-            min_doc_count: 0
-          }
+            field: 'PO.IssuedDate',
+            calendar_interval: 'year',
+            min_doc_count: 0,
+          },
         },
         rows: {
           terms: {
             size: 10,
-            field: "Organization.State.untouched"
+            field: 'Organization.State.untouched',
           },
           aggs: {
             columns: {
               date_histogram: {
-                field: "PO.IssuedDate",
-                calendar_interval: "year",
-                min_doc_count: 0
-              }
-            }
-          }
-        }
+                field: 'PO.IssuedDate',
+                calendar_interval: 'year',
+                min_doc_count: 0,
+              },
+            },
+          },
+        },
       },
-      track_total_hits: true
+      track_total_hits: true,
     }
     let { buildQuery } = createPivotScope(
       input,
@@ -2851,7 +2856,11 @@ describe('pivot', () => {
       values: [{ type: 'sum', field: 'LineItem.TotalPrice' }],
       rows: [
         { type: 'fieldValues', field: 'Organization.State', groupCounts: true },
-        { type: 'fieldValues', field: 'Organization.NameState', groupCounts: true },
+        {
+          type: 'fieldValues',
+          field: 'Organization.NameState',
+          groupCounts: true,
+        },
       ],
       columns: [
         { type: 'dateInterval', field: 'PO.IssuedDate', interval: 'year' },
@@ -2983,7 +2992,12 @@ describe('pivot', () => {
       values: [],
       rows: [
         { type: 'fieldValues', field: 'Organization.State', groupCounts: true },
-        { type: 'fieldValues', field: 'Organization.NameState', groupCounts: true, skip: true },
+        {
+          type: 'fieldValues',
+          field: 'Organization.NameState',
+          groupCounts: true,
+          skip: true,
+        },
       ],
       columns: [
         { type: 'dateInterval', field: 'PO.IssuedDate', interval: 'year' },

--- a/packages/provider-elasticsearch/test/example-types/metricGroups/pivot.test.js
+++ b/packages/provider-elasticsearch/test/example-types/metricGroups/pivot.test.js
@@ -2708,6 +2708,358 @@ describe('pivot', () => {
     let result = await buildQuery(rootPivotRequest)
     expect(result).toEqual(expected)
   })
+  it('should buildQuery without values aggregation', async () => {
+    let input = {
+      key: 'test',
+      type: 'pivot',
+      values: [{ type: 'sum', field: 'LineItem.TotalPrice', skip: true }],
+      rows: [
+        { type: 'fieldValues', field: 'Organization.State' },
+        { type: 'fieldValues', field: 'Organization.NameState' },
+      ],
+      columns: [
+        { type: 'dateInterval', field: 'PO.IssuedDate', interval: 'year' },
+        { type: 'dateInterval', field: 'PO.IssuedDate', interval: 'month' },
+      ],
+      expanded: { columns: true, rows: true },
+    }
+    let expected = {
+      track_total_hits: true,
+      aggs: {
+        rows: {
+          terms: { field: 'Organization.State.untouched', size: 10 },
+          aggs: {
+            rows: {
+              terms: { field: 'Organization.NameState.untouched', size: 10 },
+              aggs: {
+                columns: {
+                  date_histogram: {
+                    field: 'PO.IssuedDate',
+                    calendar_interval: 'year',
+                    min_doc_count: 0,
+                  },
+                  aggs: {
+                    columns: {
+                      date_histogram: {
+                        field: 'PO.IssuedDate',
+                        calendar_interval: 'month',
+                        min_doc_count: 0,
+                      },
+                    },
+                  },
+                },
+              },
+            },
+            columns: {
+              date_histogram: {
+                field: 'PO.IssuedDate',
+                calendar_interval: 'year',
+                min_doc_count: 0,
+              },
+              aggs: {
+                columns: {
+                  date_histogram: {
+                    field: 'PO.IssuedDate',
+                    calendar_interval: 'month',
+                    min_doc_count: 0,
+                  },
+                },
+              },
+            },
+          },
+        },
+        columns: {
+          date_histogram: {
+            field: 'PO.IssuedDate',
+            calendar_interval: 'year',
+            min_doc_count: 0,
+          },
+          aggs: {
+            columns: {
+              date_histogram: {
+                field: 'PO.IssuedDate',
+                calendar_interval: 'month',
+                min_doc_count: 0,
+              },
+            },
+          },
+        },
+      },
+    }
+    let { buildQuery } = createPivotScope(
+      input,
+      testSchemas(['Organization.NameState', 'Organization.State']),
+      () => {} // getStats(search) -> stats(field, statsArray)
+    )
+    let result = await buildQuery(rootPivotRequest)
+    expect(result).toEqual(expected)
+  })
+  it('should buildQuery and skip some grouping', async () => {
+    let input = {
+      key: 'test',
+      type: 'pivot',
+      values: [],
+      rows: [
+        { type: 'fieldValues', field: 'Organization.State' },
+        { type: 'fieldValues', field: 'Organization.NameState', skip: true },
+      ],
+      columns: [
+        { type: 'dateInterval', field: 'PO.IssuedDate', interval: 'year' },
+        { type: 'dateInterval', field: 'PO.IssuedDate', interval: 'month', skip: true },
+      ],
+      expanded: { columns: true, rows: true, skipValues: true },
+    }
+    let expected = {
+      aggs: {
+        columns: {
+          date_histogram: {
+            field: "PO.IssuedDate",
+            calendar_interval: "year",
+            min_doc_count: 0
+          }
+        },
+        rows: {
+          terms: {
+            size: 10,
+            field: "Organization.State.untouched"
+          },
+          aggs: {
+            columns: {
+              date_histogram: {
+                field: "PO.IssuedDate",
+                calendar_interval: "year",
+                min_doc_count: 0
+              }
+            }
+          }
+        }
+      },
+      track_total_hits: true
+    }
+    let { buildQuery } = createPivotScope(
+      input,
+      testSchemas(['Organization.NameState', 'Organization.State']),
+      () => {} // getStats(search) -> stats(field, statsArray)
+    )
+    let result = await buildQuery(rootPivotRequest)
+    expect(result).toEqual(expected)
+  })
+  it('should buildQuery with grouping cardinality', async () => {
+    let input = {
+      key: 'test',
+      type: 'pivot',
+      values: [{ type: 'sum', field: 'LineItem.TotalPrice' }],
+      rows: [
+        { type: 'fieldValues', field: 'Organization.State', groupCounts: true },
+        { type: 'fieldValues', field: 'Organization.NameState', groupCounts: true },
+      ],
+      columns: [
+        { type: 'dateInterval', field: 'PO.IssuedDate', interval: 'year' },
+        { type: 'dateInterval', field: 'PO.IssuedDate', interval: 'month' },
+      ],
+      expanded: { columns: true, rows: true },
+    }
+    let expected = {
+      aggs: {
+        'pivotMetric-sum-LineItem.TotalPrice': {
+          sum: { field: 'LineItem.TotalPrice' },
+        },
+        columns: {
+          date_histogram: {
+            field: 'PO.IssuedDate',
+            calendar_interval: 'year',
+            min_doc_count: 0,
+          },
+          aggs: {
+            columns: {
+              date_histogram: {
+                field: 'PO.IssuedDate',
+                calendar_interval: 'month',
+                min_doc_count: 0,
+              },
+              aggs: {
+                'pivotMetric-sum-LineItem.TotalPrice': {
+                  sum: { field: 'LineItem.TotalPrice' },
+                },
+              },
+            },
+            'pivotMetric-sum-LineItem.TotalPrice': {
+              sum: { field: 'LineItem.TotalPrice' },
+            },
+          },
+        },
+        rows: {
+          terms: { size: 10, field: 'Organization.State.untouched' },
+          aggs: {
+            rows: {
+              terms: { size: 10, field: 'Organization.NameState.untouched' },
+              aggs: {
+                'pivotMetric-sum-LineItem.TotalPrice': {
+                  sum: { field: 'LineItem.TotalPrice' },
+                },
+                columns: {
+                  date_histogram: {
+                    field: 'PO.IssuedDate',
+                    calendar_interval: 'year',
+                    min_doc_count: 0,
+                  },
+                  aggs: {
+                    columns: {
+                      date_histogram: {
+                        field: 'PO.IssuedDate',
+                        calendar_interval: 'month',
+                        min_doc_count: 0,
+                      },
+                      aggs: {
+                        'pivotMetric-sum-LineItem.TotalPrice': {
+                          sum: { field: 'LineItem.TotalPrice' },
+                        },
+                      },
+                    },
+                    'pivotMetric-sum-LineItem.TotalPrice': {
+                      sum: { field: 'LineItem.TotalPrice' },
+                    },
+                  },
+                },
+              },
+            },
+            rowsGroupCount: {
+              cardinality: {
+                precision_threshold: 100,
+                field: 'Organization.NameState.untouched',
+              },
+            },
+            'pivotMetric-sum-LineItem.TotalPrice': {
+              sum: { field: 'LineItem.TotalPrice' },
+            },
+            columns: {
+              date_histogram: {
+                field: 'PO.IssuedDate',
+                calendar_interval: 'year',
+                min_doc_count: 0,
+              },
+              aggs: {
+                columns: {
+                  date_histogram: {
+                    field: 'PO.IssuedDate',
+                    calendar_interval: 'month',
+                    min_doc_count: 0,
+                  },
+                  aggs: {
+                    'pivotMetric-sum-LineItem.TotalPrice': {
+                      sum: { field: 'LineItem.TotalPrice' },
+                    },
+                  },
+                },
+                'pivotMetric-sum-LineItem.TotalPrice': {
+                  sum: { field: 'LineItem.TotalPrice' },
+                },
+              },
+            },
+          },
+        },
+        rowsGroupCount: {
+          cardinality: {
+            precision_threshold: 100,
+            field: 'Organization.State.untouched',
+          },
+        },
+      },
+      track_total_hits: true,
+    }
+
+    let { buildQuery } = createPivotScope(
+      input,
+      testSchemas(['Organization.NameState', 'Organization.State']),
+      () => {} // getStats(search) -> stats(field, statsArray)
+    )
+    let result = await buildQuery(rootPivotRequest)
+    expect(result).toEqual(expected)
+  })
+  it('should buildQuery replace the deepest grouping with cardinality', async () => {
+    let input = {
+      key: 'test',
+      type: 'pivot',
+      values: [],
+      rows: [
+        { type: 'fieldValues', field: 'Organization.State', groupCounts: true },
+        { type: 'fieldValues', field: 'Organization.NameState', groupCounts: true, skip: true },
+      ],
+      columns: [
+        { type: 'dateInterval', field: 'PO.IssuedDate', interval: 'year' },
+        { type: 'dateInterval', field: 'PO.IssuedDate', interval: 'month' },
+      ],
+      expanded: {
+        columns: true,
+        rows: true,
+      },
+    }
+    let expected = {
+      aggs: {
+        columns: {
+          date_histogram: {
+            field: 'PO.IssuedDate',
+            calendar_interval: 'year',
+            min_doc_count: 0,
+          },
+          aggs: {
+            columns: {
+              date_histogram: {
+                field: 'PO.IssuedDate',
+                calendar_interval: 'month',
+                min_doc_count: 0,
+              },
+            },
+          },
+        },
+        rows: {
+          terms: {
+            size: 10,
+            field: 'Organization.State.untouched',
+          },
+          aggs: {
+            columns: {
+              date_histogram: {
+                field: 'PO.IssuedDate',
+                calendar_interval: 'year',
+                min_doc_count: 0,
+              },
+              aggs: {
+                columns: {
+                  date_histogram: {
+                    field: 'PO.IssuedDate',
+                    calendar_interval: 'month',
+                    min_doc_count: 0,
+                  },
+                },
+              },
+            },
+            rowsGroupCount: {
+              cardinality: {
+                field: 'Organization.NameState.untouched',
+                precision_threshold: 100,
+              },
+            },
+          },
+        },
+        rowsGroupCount: {
+          cardinality: {
+            field: 'Organization.State.untouched',
+            precision_threshold: 100,
+          },
+        },
+      },
+      track_total_hits: true,
+    }
+
+    let { buildQuery } = createPivotScope(
+      input,
+      testSchemas(['Organization.NameState', 'Organization.State']),
+      () => {} // getStats(search) -> stats(field, statsArray)
+    )
+    let result = await buildQuery(rootPivotRequest)
+    expect(result).toEqual(expected)
+  })
   it('should paginateExpandedGroups for not expanded', async () => {
     let rows = [
       { type: 'fieldValues', field: 'Organization.State' },
@@ -2733,7 +3085,7 @@ describe('pivot', () => {
       () => {}
     )
 
-    let expectedIntial = {
+    let expectedInitial = {
       type: 'rows',
       columns: {
         drilldown: [],
@@ -2747,7 +3099,7 @@ describe('pivot', () => {
       },
     }
 
-    expect(getInitialRequest(rowsExpansion)).toEqual(expectedIntial)
+    expect(getInitialRequest(rowsExpansion)).toEqual(expectedInitial)
 
     let includeValues = [
       'New York',
@@ -2842,7 +3194,7 @@ describe('pivot', () => {
       () => {}
     )
 
-    let expectedIntial = {
+    let expectedInitial = {
       type: 'rows',
       columns: {
         drilldown: [],
@@ -2864,7 +3216,7 @@ describe('pivot', () => {
         totals: false,
       },
     }
-    expect(getInitialRequest(rowsExpansion)).toEqual(expectedIntial)
+    expect(getInitialRequest(rowsExpansion)).toEqual(expectedInitial)
 
     let includeValues = [
       'New York',


### PR DESCRIPTION
* [x] ElasticSearch pivot: adding `groupCounts` and `skip` per group/value config. `groupCounts` flag adds subgroups counter to the parent level. `skip` flag skips the groping level in aggregation