### PR TITLE
Await export onWrite callback

### DIFF
--- a/.changeset/six-wasps-rhyme.md
+++ b/.changeset/six-wasps-rhyme.md
@@ -1,0 +1,5 @@
+---
+'contexture-export': patch
+---
+
+Await onWrite callback

--- a/packages/export/src/csv.js
+++ b/packages/export/src/csv.js
@@ -37,7 +37,7 @@ export default ({
           )
         )
         recordsWritten = recordsWritten + _.getOr(1, 'recordCount', r)
-        onWrite({ recordsWritten, record: r })
+        await onWrite({ recordsWritten, record: r })
       }
       await stream.end()
     })(),


### PR DESCRIPTION
We have to await `onWrite` callback when exporting csvs, otherwise [this returned promise](https://github.com/smartprocure/contexture/pull/137/files#diff-446ca2ccce95352d65a8231acb4bcb2f6f8b8c2a5ce47db84f942479d579c6e5R23) will resolve before all the chunks have been written.