### PR TITLE
Move elasticsearch highlighting code out of results type

### DIFF
--- a/packages/provider-elasticsearch/src/example-types/results/highlighting.js
+++ b/packages/provider-elasticsearch/src/example-types/results/highlighting.js
@@ -151,7 +151,7 @@ export let highlightResults = (
   }
 }
 
-export let getSearchHighlight = (schema, node) => {
+export let getHighlightSettings = (schema, node) => {
   // Global schema highlight configuration
   let schemaHighlight =
     node.highlight !== false && schema.elasticsearch.highlight
@@ -197,7 +197,7 @@ export let getSearchHighlight = (schema, node) => {
             _.pick(_.concat(node.include, schemaInlineAliases), filtered)
     )(schemaHighlight)
 
-    return _.merge(
+    let searchHighlight = _.merge(
       {
         // The default schema highlighting settings w/o the fields
         pre_tags: ['<b class="search-highlight">'],
@@ -208,5 +208,9 @@ export let getSearchHighlight = (schema, node) => {
       },
       nodeHighlight
     )
+
+    return { schemaHighlight, searchHighlight }
   }
+
+  return {}
 }

--- a/packages/provider-elasticsearch/src/example-types/results/highlighting.js
+++ b/packages/provider-elasticsearch/src/example-types/results/highlighting.js
@@ -150,3 +150,63 @@ export let highlightResults = (
     mainHighlighted,
   }
 }
+
+export let getSearchHighlight = (schema, node) => {
+  // Global schema highlight configuration
+  let schemaHighlight =
+    node.highlight !== false && schema.elasticsearch.highlight
+  // Specific search highlight override
+  let nodeHighlight = _.isPlainObject(node.highlight) ? node.highlight : {}
+
+  // to be able to override schema highlight config with node config
+  if (nodeHighlight.override) {
+    schemaHighlight = nodeHighlight.override
+    nodeHighlight = _.omit('override', nodeHighlight)
+  }
+
+  // Highlighting starts with defaults in the schema first
+  if (schemaHighlight) {
+    let showOtherMatches = _.getOr(false, 'showOtherMatches', node)
+    let schemaInline = _.getOr([], 'inline', schemaHighlight)
+    let schemaInlineAliases = _.flow(
+      _.getOr({}, 'inlineAliases'),
+      _.entries,
+      _.filter(([k]) => _.includes(k, node.include)),
+      _.flatten
+    )(schemaHighlight)
+
+    // Concat the search specific override fields with the schema `inline` so we have them as targets for highlight replacement
+    schemaHighlight = _.set(
+      'inline',
+      _.concat(schemaInline, _.keys(nodeHighlight.fields)),
+      schemaHighlight
+    )
+    // Convert the highlight fields from array to an object map
+    let fields = _.flow(
+      _.pick(['inline', 'additionalFields', 'nested']), // Get the highlight fields we will be working with
+      _.values,
+      _.flatten,
+      _.concat(schemaInlineAliases), // Include the provided field aliases if any
+      _.uniq,
+      arrayToHighlightsFieldMap, // Convert the array to object map so we can simply _.pick again
+      (filtered) =>
+        showOtherMatches
+          ? // Highlight on all fields specified in the initial _.pick above.
+            filtered
+          : // Only highlight on the fields listed in the node include section and their aliases (if any)
+            _.pick(_.concat(node.include, schemaInlineAliases), filtered)
+    )(schemaHighlight)
+
+    return _.merge(
+      {
+        // The default schema highlighting settings w/o the fields
+        pre_tags: ['<b class="search-highlight">'],
+        post_tags: ['</b>'],
+        require_field_match: false,
+        number_of_fragments: 0,
+        fields,
+      },
+      nodeHighlight
+    )
+  }
+}

--- a/packages/provider-elasticsearch/src/example-types/results/index.js
+++ b/packages/provider-elasticsearch/src/example-types/results/index.js
@@ -1,6 +1,6 @@
 import F from 'futil'
 import _ from 'lodash/fp.js'
-import { highlightResults, getSearchHighlight } from './highlighting.js'
+import { highlightResults, getHighlightSettings } from './highlighting.js'
 import { getField } from '../../utils/fields.js'
 
 export default {
@@ -28,7 +28,10 @@ export default {
 
     let resultColumns = node.include
 
-    let searchHighlight = getSearchHighlight(schema, node)
+    let { schemaHighlight, searchHighlight } = getHighlightSettings(
+      schema,
+      node
+    )
 
     if (searchHighlight) {
       // Setup the DEFAULT highlight config object with the calculated fields above

--- a/packages/provider-elasticsearch/src/example-types/results/index.js
+++ b/packages/provider-elasticsearch/src/example-types/results/index.js
@@ -1,6 +1,6 @@
 import F from 'futil'
 import _ from 'lodash/fp.js'
-import { highlightResults, arrayToHighlightsFieldMap } from './highlighting.js'
+import { highlightResults, getSearchHighlight } from './highlighting.js'
 import { getField } from '../../utils/fields.js'
 
 export default {
@@ -26,70 +26,20 @@ export default {
         excludes: node.exclude,
       })
 
-    // Global schema highlight configuration
-    let schemaHighlight =
-      node.highlight !== false && schema.elasticsearch.highlight
-    // Specific search highlight override
-    let searchHighlight = _.isPlainObject(node.highlight) ? node.highlight : {}
     let resultColumns = node.include
 
-    // to be able to override schema highlight config with node config
-    if (searchHighlight.override) {
-      schemaHighlight = searchHighlight.override
-      searchHighlight = _.omit('override', searchHighlight)
-    }
+    let searchHighlight = getSearchHighlight(schema, node)
 
-    // Highlighting starts with defaults in the schema first
-    if (schemaHighlight) {
-      let showOtherMatches = _.getOr(false, 'showOtherMatches', node)
-      let schemaInline = _.getOr([], 'inline', schemaHighlight)
-      let schemaInlineAliases = _.flow(
-        _.getOr({}, 'inlineAliases'),
-        _.entries,
-        _.filter(([k]) => _.includes(k, node.include)),
-        _.flatten
-      )(schemaHighlight)
-
-      // Concat the search specific override fields with the schema `inline` so we have them as targets for highlight replacement
-      schemaHighlight = _.set(
-        'inline',
-        _.concat(schemaInline, _.keys(searchHighlight.fields)),
-        schemaHighlight
-      )
-      // Convert the highlight fields from array to an object map
-      let fields = _.flow(
-        _.pick(['inline', 'additionalFields', 'nested']), // Get the highlight fields we will be working with
-        _.values,
-        _.flatten,
-        _.concat(schemaInlineAliases), // Include the provided field aliases if any
-        _.uniq,
-        arrayToHighlightsFieldMap, // Convert the array to object map so we can simply _.pick again
-        (filtered) =>
-          showOtherMatches
-            ? // Highlight on all fields specified in the initial _.pick above.
-              filtered
-            : // Only highlight on the fields listed in the node include section and their aliases (if any)
-              _.pick(_.concat(node.include, schemaInlineAliases), filtered)
-      )(schemaHighlight)
-
+    if (searchHighlight) {
       // Setup the DEFAULT highlight config object with the calculated fields above
       // and merge with the search specific config
-      searchObj.highlight = _.merge(
-        {
-          // The default schema highlighting settings w/o the fields
-          pre_tags: ['<b class="search-highlight">'],
-          post_tags: ['</b>'],
-          require_field_match: false,
-          number_of_fragments: 0,
-          fields,
-        },
-        searchHighlight
-      )
+      searchObj.highlight = searchHighlight
 
       // Make sure the search specific overrides are part of the node include.
       // This way they do not have to be added manually. All that is needed is the highlight config
+      let nodeHighlight = _.isPlainObject(node.highlight) ? node.highlight : {}
       resultColumns = _.flow(
-        _.concat(_.keys(searchHighlight.fields)),
+        _.concat(_.keys(nodeHighlight.fields)),
         _.uniq,
         _.compact
       )(node.include)


### PR DESCRIPTION
Move highlighting related code from the results example type to the highlighting util file. There's no change in behavior, just moving code around.