### PR TITLE
Refactor: break down highlightResults function

### DIFF
--- a/packages/provider-elasticsearch/src/example-types/results/highlighting.js
+++ b/packages/provider-elasticsearch/src/example-types/results/highlighting.js
@@ -127,9 +127,9 @@ let getAdditionalFields = (
 // TODO: Make this function pure, do not mutate `hit._source`
 export let highlightResults = (highlightFields, hit, ...args) => {
   // TODO: Make this function pure, do not mutate `hit._source`
-  let additionalFields = getAdditionalFields(schemaHighlight, hit, ...args)
+  let additionalFields = getAdditionalFields(highlightFields, hit, ...args)
 
-  let { inline, inlineAliases } = schemaHighlight
+  let { inline, inlineAliases } = highlightFields
   let inlineKeys = _.keys(arrayToHighlightsFieldMap(inline))
 
   // Copy over all inline highlighted fields

--- a/packages/provider-elasticsearch/src/example-types/results/highlighting.js
+++ b/packages/provider-elasticsearch/src/example-types/results/highlighting.js
@@ -140,7 +140,7 @@ export let highlightResults = (schemaHighlight, hit, ...args) => {
       inlineHighlightInSource(hit, field)
     }
     // Do the field replacement for the inlineAliases fields
-    for (let [to, from] in _.toPairs(inlineAliases)) {
+    for (let [to, from] of _.toPairs(inlineAliases)) {
       if (hit.highlight[from]) {
         // `inline` takes priority over `inlineAliases`, so only replace the
         // `_source` value if the field is not in `inline` OR if there's no

--- a/packages/provider-elasticsearch/src/example-types/results/highlighting.test.js
+++ b/packages/provider-elasticsearch/src/example-types/results/highlighting.test.js
@@ -50,9 +50,9 @@ describe('highlighting', () => {
         additionalFields: [],
       })
     })
-    it.only('should work with inline', () => {
+    it('should work with inline', () => {
       let highlightFields = {
-        // inline: ['title', 'description'],
+        inline: ['title', 'description'],
       }
       let hit = {
         _source: {

--- a/packages/provider-elasticsearch/src/example-types/results/highlighting.test.js
+++ b/packages/provider-elasticsearch/src/example-types/results/highlighting.test.js
@@ -29,7 +29,6 @@ describe('highlighting', () => {
             value: 'b',
           },
         ],
-        mainHighlighted: true,
       })
     })
     it('should work without includes', () => {
@@ -49,12 +48,11 @@ describe('highlighting', () => {
       let result = highlightResults(highlightFields, hit)
       expect(result).toEqual({
         additionalFields: [],
-        mainHighlighted: true,
       })
     })
-    it('should work with inline', () => {
+    it.only('should work with inline', () => {
       let highlightFields = {
-        inline: ['title', 'description'],
+        // inline: ['title', 'description'],
       }
       let hit = {
         _source: {
@@ -70,7 +68,6 @@ describe('highlighting', () => {
       })
       expect(result).toEqual({
         additionalFields: [],
-        mainHighlighted: true,
       })
     })
     it('should work with inline and .* object', () => {
@@ -110,7 +107,6 @@ describe('highlighting', () => {
       })
       expect(result).toEqual({
         additionalFields: [],
-        mainHighlighted: true,
       })
     })
     it('should work with inline and object', () => {
@@ -144,7 +140,6 @@ describe('highlighting', () => {
       })
       expect(result).toEqual({
         additionalFields: [],
-        mainHighlighted: true,
       })
     })
     it('should work with inlineAliases', () => {
@@ -171,7 +166,6 @@ describe('highlighting', () => {
       })
       expect(result).toEqual({
         additionalFields: [],
-        mainHighlighted: true,
       })
     })
     it('inline should precede inlineAliases', () => {
@@ -196,7 +190,6 @@ describe('highlighting', () => {
       })
       expect(result).toEqual({
         additionalFields: [],
-        mainHighlighted: true,
       })
     })
     it('arrayToHighlightsFieldMap should work', () => {
@@ -251,7 +244,6 @@ describe('highlighting', () => {
       })
       expect(result).toEqual({
         additionalFields: [],
-        mainHighlighted: false,
       })
     })
     it('should work with nested and filterNested', () => {
@@ -288,7 +280,6 @@ describe('highlighting', () => {
       })
       expect(result).toEqual({
         additionalFields: [],
-        mainHighlighted: false,
       })
     })
 
@@ -318,7 +309,6 @@ describe('highlighting', () => {
       })
       expect(result).toEqual({
         additionalFields: [],
-        mainHighlighted: false,
       })
     })
   })

--- a/packages/provider-elasticsearch/src/example-types/results/index.js
+++ b/packages/provider-elasticsearch/src/example-types/results/index.js
@@ -65,12 +65,14 @@ export default {
             hit, // The ES result
             schema.elasticsearch.nestedPath,
             resultColumns, // The columns to return
-            schemaHighlight.filterNested // Only return the highlighted fields
+            schemaHighlight.filterNested // Whether to only return the highlighted fields
           )
           additionalFields = highlightObject.additionalFields
         }
 
-        // TODO - If nested path, iterate properties on nested path, filtering out nested path results unless mainHighlighted or relevant nested fields have "<b></b>" tags in them
+        // TODO - If nested path, iterate properties on nested path, filtering
+        // out nested path results unless mainHighlighted or relevant nested
+        // fields have "<b></b>" tags in them
         return {
           additionalFields: schemaHighlight ? additionalFields : [],
           ...hit,


### PR DESCRIPTION
Break down the humongous `highlightResults` function into smaller functions. There are lots of other refactors to do but this is a good start.