### PR TITLE
Refactor: break down getAdditionalFields

### DIFF
--- a/packages/provider-elasticsearch/src/example-types/results/highlighting.js
+++ b/packages/provider-elasticsearch/src/example-types/results/highlighting.js
@@ -1,13 +1,8 @@
 import F from 'futil'
 import _ from 'lodash/fp.js'
 
-function regexify(criteria) {
-  return new RegExp(criteria)
-}
-
-function anyRegexesMatch(regexes, criteria) {
-  return _.some(_.invokeMap(_.map(regexify, regexes), 'test', criteria))
-}
+export let anyRegexesMatch = (regexes, criteria) =>
+  !!_.find((str) => new RegExp(str).test(criteria), regexes)
 
 // Convert the fields array to object map where we only pick the first key from the objects
 // Highlight fields can be either strings or objects with a single key which value is the ES highlights object config
@@ -40,19 +35,17 @@ let inlineHighlightInSource = (hit, fieldName) => {
   }
 }
 
-let getAdditionalFields = (
-  highlightFields, // The schema highlight configuration
-  hit, // The ES result
-  pathToNested, // schema.elasticsearch.nestedPath
-  include, // The columns to return
-  filterNested // Whether to only return the highlighted fields
-) => {
-  // Handle Results Highlighting
+let getAdditionalFields = ({
+  highlightFields,
+  hit,
+  pathToNested,
+  include,
+  inlineKeys,
+}) => {
   let additionalFields = []
   let { additional, additionalExclusions, inline, nested } = highlightFields
-  let inlineKeys = _.keys(arrayToHighlightsFieldMap(inline))
 
-  F.eachIndexed((value, fieldName) => {
+  F.eachIndexed((fieldValue, fieldName) => {
     // Whether `fieldName` is matched by any field name in `additional`
     let additionalMatches = anyRegexesMatch(additional, fieldName)
 
@@ -73,64 +66,105 @@ let getAdditionalFields = (
     ) {
       additionalFields.push({
         label: fieldName,
-        value: value[0],
+        value: fieldValue[0],
       })
-    } else if (_.includes(fieldName, nested)) {
-      if (_.isArray(value) && !_.includes(pathToNested, fieldName)) {
-        additionalFields.push({
-          label: fieldName,
-          value,
-        })
-      } else {
-        // Handle Nested Item Highlighting Replacement
-        if (fieldName === pathToNested)
-          // Clarify [{a}, {b}] case and not [a,b] case (ie, does not handle http://stackoverflow.com/questions/25565546/highlight-whole-content-in-elasticsearch-for-multivalue-fields)
-          throw new Error('Arrays of scalars not supported')
+    }
 
-        let field = fieldName.replace(`${pathToNested}.`, '')
-        // For arrays, strip the highlighting wrapping and compare to the array contents to match up
-        _.each(function (val) {
-          let originalValue = val.replace(
-            /<b class="search-highlight">|<\/b>/g,
-            ''
-          )
-          let childItem = _.find(
-            // TODO: Remove this asap
-            (item) => _.trim(_.get(field, item)) === _.trim(originalValue),
-            _.get(pathToNested, hit._source)
-          )
-          if (childItem) childItem[field] = val
-        }, value)
-
-        if (filterNested) {
-          let filtered = _.flow(
-            _.get(pathToNested),
-            _.filter(
-              _.flow(_.get(field), _.includes('<b class="search-highlight">'))
-            )
-          )(hit._source)
-
-          F.setOn(pathToNested, filtered, hit._source)
-        }
-      }
+    if (
+      _.includes(fieldName, nested) &&
+      _.isArray(fieldValue) &&
+      !_.includes(pathToNested, fieldName)
+    ) {
+      additionalFields.push({
+        label: fieldName,
+        value: fieldValue,
+      })
     }
   }, hit.highlight)
 
-  if (filterNested && _.isEmpty(hit.highlight))
-    F.setOn(pathToNested, [], hit._source)
-
   return additionalFields
+}
+
+let handleNested = ({
+  highlightFields,
+  hit,
+  pathToNested,
+  filterNested,
+  additionalFields,
+}) => {
+  F.eachIndexed((fieldValue, fieldName) => {
+    if (
+      _.includes(fieldName, highlightFields.nested) &&
+      !_.find({ label: fieldName }, additionalFields)
+    ) {
+      // Handle Nested Item Highlighting Replacement
+      if (fieldName === pathToNested)
+        // Clarify [{a}, {b}] case and not [a,b] case (ie, does not handle http://stackoverflow.com/questions/25565546/highlight-whole-content-in-elasticsearch-for-multivalue-fields)
+        throw new Error('Arrays of scalars not supported')
+
+      let field = fieldName.replace(`${pathToNested}.`, '')
+      // For arrays, strip the highlighting wrapping and compare to the array contents to match up
+      _.each(function (val) {
+        let originalValue = val.replace(
+          /<b class="search-highlight">|<\/b>/g,
+          ''
+        )
+        let childItem = _.find(
+          // TODO: Remove this asap
+          (item) => _.trim(_.get(field, item)) === _.trim(originalValue),
+          _.get(pathToNested, hit._source)
+        )
+        if (childItem) childItem[field] = val
+      }, fieldValue)
+
+      if (filterNested) {
+        let filtered = _.flow(
+          _.get(pathToNested),
+          _.filter(
+            _.flow(_.get(field), _.includes('<b class="search-highlight">'))
+          )
+        )(hit._source)
+
+        F.setOn(pathToNested, filtered, hit._source)
+      }
+    }
+  }, hit.highlight)
 }
 
 // TODO: Support multiple pathToNesteds...
 // TODO: Support Regex and Function basis for all options
 // TODO: Make this function pure, do not mutate `hit._source`
-export let highlightResults = (highlightFields, hit, ...args) => {
-  // TODO: Make this function pure, do not mutate `hit._source`
-  let additionalFields = getAdditionalFields(highlightFields, hit, ...args)
-
+export let highlightResults = (
+  highlightFields, // The schema highlight configuration
+  hit, // The ES result
+  pathToNested, // schema.elasticsearch.nestedPath
+  include, // The columns to return
+  filterNested // Whether to only return the highlighted fields
+) => {
   let { inline, inlineAliases } = highlightFields
   let inlineKeys = _.keys(arrayToHighlightsFieldMap(inline))
+
+  let additionalFields = getAdditionalFields({
+    highlightFields,
+    hit,
+    pathToNested,
+    include,
+    inlineKeys,
+  })
+
+  // TODO: Make this function pure, do not mutate `hit._source`
+  handleNested({
+    highlightFields,
+    hit,
+    pathToNested,
+    filterNested,
+    additionalFields,
+  })
+
+  // TODO: Do not mutate `hit._source`
+  if (filterNested && _.isEmpty(hit.highlight)) {
+    F.setOn(pathToNested, [], hit._source)
+  }
 
   // Copy over all inline highlighted fields
   if (hit.highlight) {
@@ -138,6 +172,7 @@ export let highlightResults = (highlightFields, hit, ...args) => {
       // TODO: Make this function pure, do not mutate `hit._source`
       inlineHighlightInSource(hit, field)
     }
+
     // Do the field replacement for the inlineAliases fields
     for (let [field, mapToField] of _.toPairs(inlineAliases)) {
       // if we have a highlight result matching the inlineAliases TO field

--- a/packages/provider-elasticsearch/src/example-types/results/highlighting.test.js
+++ b/packages/provider-elasticsearch/src/example-types/results/highlighting.test.js
@@ -1,4 +1,8 @@
-import { highlightResults, arrayToHighlightsFieldMap } from './highlighting.js'
+import {
+  highlightResults,
+  arrayToHighlightsFieldMap,
+  anyRegexesMatch,
+} from './highlighting.js'
 
 describe('highlighting', () => {
   describe('highlightResults', () => {
@@ -311,5 +315,20 @@ describe('highlighting', () => {
         additionalFields: [],
       })
     })
+  })
+})
+
+describe('anyRegexesMatch()', () => {
+  it('should match', () => {
+    let actual = anyRegexesMatch(['non-matching', 'nested.*'], 'nested.field')
+    expect(actual).toEqual(true)
+  })
+
+  it('should not match', () => {
+    let actual = anyRegexesMatch(
+      ['non-matching', 'non-matching.*'],
+      'nested.field'
+    )
+    expect(actual).toEqual(false)
   })
 })


### PR DESCRIPTION
Break down another big function into smaller functions.

Also `anyRegexesMatch` was broken so this PR fixes it and includes a couple unit tests for it.