### PR TITLE
Merge results node highlighting settings into schema highlighting settings

### DIFF
--- a/.changeset/nasty-grapes-worry.md
+++ b/.changeset/nasty-grapes-worry.md
@@ -1,0 +1,5 @@
+---
+'contexture-elasticsearch': patch
+---
+
+Merge results node highlighting settings into schema highlighting settings


### PR DESCRIPTION
We added the ability to override schema highlighting configuration in the results node in https://github.com/smartprocure/contexture/pull/64. However, it is not convenient as the node overrides replace the schema highlighting config instead of merging into them, leading users to have to repeat the schema highlighting config everywhere they need to override it.