### PR TITLE
Clear arrays when nestedPath is not in highlights

### DIFF
--- a/.changeset/fast-files-teach.md
+++ b/.changeset/fast-files-teach.md
@@ -1,0 +1,5 @@
+---
+'contexture-elasticsearch': patch
+---
+
+Clear arrays when nestedPath is not in highlights

--- a/packages/provider-elasticsearch/src/example-types/results/highlighting.js
+++ b/packages/provider-elasticsearch/src/example-types/results/highlighting.js
@@ -141,6 +141,10 @@ let handleNested = ({
       }
     }
   }, hit.highlight)
+
+  if (filterNested && !(nestedPath in hit.highlight)) {
+    F.setOn(nestedPath, [], hit._source)
+  }
 }
 
 // TODO: Support multiple nestedPaths...
@@ -152,7 +156,7 @@ export let highlightResults = ({
   hit, // The ES result
   include, // The columns to return
 }) => {
-  let { inline, inlineAliases, nestedPath, filterNested } = schemaHighlight
+  let { inline, inlineAliases } = schemaHighlight
   let inlineKeys = _.keys(arrayToHighlightsFieldMap(inline))
 
   let additionalFields = getAdditionalFields({
@@ -169,11 +173,6 @@ export let highlightResults = ({
     hit,
     additionalFields,
   })
-
-  // TODO: Do not mutate `hit._source`
-  if (filterNested && _.isEmpty(hit.highlight)) {
-    F.setOn(nestedPath, [], hit._source)
-  }
 
   // Copy over all inline highlighted fields
   if (hit.highlight) {

--- a/packages/provider-elasticsearch/src/example-types/results/highlighting.js
+++ b/packages/provider-elasticsearch/src/example-types/results/highlighting.js
@@ -142,8 +142,12 @@ let handleNested = ({
     }
   }, hit.highlight)
 
-  if (filterNested && !(nestedPath in hit.highlight)) {
-    F.setOn(nestedPath, [], hit._source)
+  if (filterNested) {
+    for (const path of nested) {
+      if (!(path in hit.highlight)) {
+        F.setOn(nestedPath, [], hit._source)
+      }
+    }
   }
 }
 

--- a/packages/provider-elasticsearch/src/example-types/results/highlighting.test.js
+++ b/packages/provider-elasticsearch/src/example-types/results/highlighting.test.js
@@ -301,30 +301,34 @@ describe('highlighting', () => {
         additionalFields: [],
       })
     })
-
-    it('should clear nested when filterNested and highlight is empty', () => {
+    it('should clear nested when filterNested and highlight does not contain nestedPath', () => {
       let schemaHighlight = {
         nested: ['comments.text'],
         nestedPath: 'comments',
         filterNested: true,
+        inline: ['title'],
       }
       let hit = {
         _source: {
-          title: '...',
-          description: '...',
-          comments: [{ text: 'foo' }, { text: 'bar' }, { text: 'baz' }],
+          title: 'The quick brown fox jumps over the lazy dog',
+          comments: [
+            { text: 'John Snow' },
+            { text: 'Anakin Skywalker' },
+            { text: 'Neo' },
+          ],
         },
-        highlight: {},
+        highlight: {
+          title: ['The quick brown <em>fox</em> jumps over the lazy dog'],
+        },
       }
       let result = highlightResults({
         schemaHighlight,
         nodeHighlight,
         hit,
-        include: ['title', 'description', 'comments.text'],
+        include: ['title', 'comments.text'],
       })
       expect(hit._source).toEqual({
-        title: '...',
-        description: '...',
+        title: 'The quick brown <em>fox</em> jumps over the lazy dog',
         comments: [],
       })
       expect(result).toEqual({


### PR DESCRIPTION
This PR fixes an edge case in the results example type where the source value for an array at path `nestedPath` does not get cleared if `filterNested` is set but there are no highlights for `nestedPath`.