### PR TITLE
Fix regression in PR #159

### DIFF
--- a/.changeset/neat-doors-cheat.md
+++ b/.changeset/neat-doors-cheat.md
@@ -1,0 +1,5 @@
+---
+'contexture-elasticsearch': patch
+---
+
+Fix regression in PR #159

--- a/packages/provider-elasticsearch/src/example-types/results/highlighting.js
+++ b/packages/provider-elasticsearch/src/example-types/results/highlighting.js
@@ -144,7 +144,7 @@ let handleNested = ({
 
   if (filterNested) {
     for (const path of nested) {
-      if (!(path in hit.highlight)) {
+      if (!_.has(path, hit.highlight)) {
         F.setOn(nestedPath, [], hit._source)
       }
     }


### PR DESCRIPTION
Fix regression introduced in https://github.com/smartprocure/contexture/pull/159 where the `in` operator fails if the right-hand side is `undefined`