### PR TITLE
Allow filtering facet options when they are ObjectIDs

### DIFF
--- a/.changeset/thirty-squids-tease.md
+++ b/.changeset/thirty-squids-tease.md
@@ -1,0 +1,5 @@
+---
+'contexture-mongo': patch
+---
+
+Fix mongo facet filter query splitting

--- a/packages/provider-mongo/src/example-types/facet.js
+++ b/packages/provider-mongo/src/example-types/facet.js
@@ -23,9 +23,9 @@ let sortAndLimitIfNotSearching = (should, limit) =>
   sortAndLimitIfSearching(!should, limit)
 
 let getSearchableKeysList = _.flow(
-  _.getOr('_strfield', 'label.fields'),
+  _.getOr('_nodeFieldStr', 'label.fields'),
   _.castArray,
-  _.map((label) => (label === '_strfield' ? label : `label.${label}`))
+  _.map((label) => (label === '_nodeFieldStr' ? label : `label.${label}`))
 )
 
 let getMatchesForMultipleKeywords = (list, filterWords) => ({
@@ -65,7 +65,7 @@ let setMatchOperators = (node) => {
 
 let mapKeywordFilters = (node) => [
   // Cast field we're searching on to string to enable regex matches on it.
-  { $addFields: { _strfield: { $toString: '$_id' } } },
+  { $addFields: { _nodeFieldStr: { $toString: '$_id' } } },
   { $match: setMatchOperators(node) },
 ]
 

--- a/packages/provider-mongo/src/example-types/facet.test.js
+++ b/packages/provider-mongo/src/example-types/facet.test.js
@@ -69,7 +69,7 @@ describe('facet', () => {
         $match: {
           $and: [
             {
-              _strfield: {
+              _nodeFieldStr: {
                 $options: 'i',
                 $regex: 'cable',
               },
@@ -94,13 +94,13 @@ describe('facet', () => {
         $match: {
           $and: [
             {
-              _strfield: {
+              _nodeFieldStr: {
                 $options: 'i',
                 $regex: 'dis',
               },
             },
             {
-              _strfield: {
+              _nodeFieldStr: {
                 $options: 'i',
                 $regex: 'comp',
               },

--- a/packages/provider-mongo/src/example-types/facet.test.js
+++ b/packages/provider-mongo/src/example-types/facet.test.js
@@ -69,7 +69,7 @@ describe('facet', () => {
         $match: {
           $and: [
             {
-              _id: {
+              _strfield: {
                 $options: 'i',
                 $regex: 'cable',
               },
@@ -94,13 +94,13 @@ describe('facet', () => {
         $match: {
           $and: [
             {
-              _id: {
+              _strfield: {
                 $options: 'i',
                 $regex: 'dis',
               },
             },
             {
-              _id: {
+              _strfield: {
                 $options: 'i',
                 $regex: 'comp',
               },


### PR DESCRIPTION
- Split facet filter query on whitespace to fix regression introduced in https://github.com/smartprocure/contexture-mongo/pull/51 where a facet filter string would get split at alphabetical boundaries (ex: `"ab56ff"` -> `["ab", "56", "ff"]`).
- Cast field we're filtering on in the facet to a string before matching so we can apply regex to ObjectIDs as well

<img width="260" alt="image" src="https://github.com/smartprocure/contexture/assets/4336260/3e569c38-e7b3-476d-a502-8a98c460bb3a">
