### PR TITLE
[POC] Move example types into their own package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@ node_modules/
 
 # Build output
 dist
-!packages/example-types/dist
 
 # Jest
 coverage

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ node_modules/
 
 # Build output
 dist
+!packages/example-types/dist
 
 # Jest
 coverage

--- a/packages/example-types/.prettierignore
+++ b/packages/example-types/.prettierignore
@@ -1,0 +1,1 @@
+../../.prettierignore

--- a/packages/example-types/CHANGELOG.md
+++ b/packages/example-types/CHANGELOG.md
@@ -1,0 +1,1 @@
+# Changelog

--- a/packages/example-types/LICENSE
+++ b/packages/example-types/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017 SmartProcure
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/example-types/build/chunk-2GV37QZA.js
+++ b/packages/example-types/build/chunk-2GV37QZA.js
@@ -1,7 +1,5 @@
 // src/util/client.js
-import _ from "lodash/fp.js";
-var validateValueExistence = _.flow(_.get("value"), _.negate(_.isNil));
+import _ from 'lodash/fp.js'
+var validateValueExistence = _.flow(_.get('value'), _.negate(_.isNil))
 
-export {
-  validateValueExistence
-};
+export { validateValueExistence }

--- a/packages/example-types/build/chunk-2GV37QZA.js
+++ b/packages/example-types/build/chunk-2GV37QZA.js
@@ -1,0 +1,7 @@
+// src/util/client.js
+import _ from "lodash/fp.js";
+var validateValueExistence = _.flow(_.get("value"), _.negate(_.isNil));
+
+export {
+  validateValueExistence
+};

--- a/packages/example-types/build/client/bool.js
+++ b/packages/example-types/build/client/bool.js
@@ -1,18 +1,14 @@
-import {
-  validateValueExistence
-} from "../chunk-2GV37QZA.js";
+import { validateValueExistence } from '../chunk-2GV37QZA.js'
 
 // src/types/bool/client.js
 var client_default = {
   validate: validateValueExistence,
   reactors: {
-    value: "others"
+    value: 'others',
   },
   defaults: {
     field: null,
-    value: null
-  }
-};
-export {
-  client_default as default
-};
+    value: null,
+  },
+}
+export { client_default as default }

--- a/packages/example-types/build/client/bool.js
+++ b/packages/example-types/build/client/bool.js
@@ -1,0 +1,18 @@
+import {
+  validateValueExistence
+} from "../chunk-2GV37QZA.js";
+
+// src/types/bool/client.js
+var client_default = {
+  validate: validateValueExistence,
+  reactors: {
+    value: "others"
+  },
+  defaults: {
+    field: null,
+    value: null
+  }
+};
+export {
+  client_default as default
+};

--- a/packages/example-types/build/client/exists.js
+++ b/packages/example-types/build/client/exists.js
@@ -1,0 +1,18 @@
+import {
+  validateValueExistence
+} from "../chunk-2GV37QZA.js";
+
+// src/types/exists/client.js
+var client_default = {
+  validate: validateValueExistence,
+  reactors: {
+    value: "others"
+  },
+  defaults: {
+    field: null,
+    value: null
+  }
+};
+export {
+  client_default as default
+};

--- a/packages/example-types/build/client/exists.js
+++ b/packages/example-types/build/client/exists.js
@@ -1,18 +1,14 @@
-import {
-  validateValueExistence
-} from "../chunk-2GV37QZA.js";
+import { validateValueExistence } from '../chunk-2GV37QZA.js'
 
 // src/types/exists/client.js
 var client_default = {
   validate: validateValueExistence,
   reactors: {
-    value: "others"
+    value: 'others',
   },
   defaults: {
     field: null,
-    value: null
-  }
-};
-export {
-  client_default as default
-};
+    value: null,
+  },
+}
+export { client_default as default }

--- a/packages/example-types/build/provider-mongo/bool.js
+++ b/packages/example-types/build/provider-mongo/bool.js
@@ -1,0 +1,11 @@
+// src/types/bool/provider-mongo.js
+import _ from "lodash/fp.js";
+var provider_mongo_default = {
+  hasValue: ({ value }) => _.isBoolean(value),
+  filter: ({ field, value }) => ({
+    [field]: value || { $ne: true }
+  })
+};
+export {
+  provider_mongo_default as default
+};

--- a/packages/example-types/build/provider-mongo/bool.js
+++ b/packages/example-types/build/provider-mongo/bool.js
@@ -1,11 +1,9 @@
 // src/types/bool/provider-mongo.js
-import _ from "lodash/fp.js";
+import _ from 'lodash/fp.js'
 var provider_mongo_default = {
   hasValue: ({ value }) => _.isBoolean(value),
   filter: ({ field, value }) => ({
-    [field]: value || { $ne: true }
-  })
-};
-export {
-  provider_mongo_default as default
-};
+    [field]: value || { $ne: true },
+  }),
+}
+export { provider_mongo_default as default }

--- a/packages/example-types/build/provider-mongo/exists.js
+++ b/packages/example-types/build/provider-mongo/exists.js
@@ -1,20 +1,21 @@
 // src/types/exists/provider-mongo.js
-import _ from "lodash/fp.js";
+import _ from 'lodash/fp.js'
 var provider_mongo_default = {
   hasValue: ({ value }) => _.isBoolean(value),
-  filter: ({ field, value }) => value ? {
-    $and: [
-      { [field]: { $exists: value, $ne: "" } },
-      { [field]: { $ne: null } }
-    ]
-  } : {
-    $or: [
-      { [field]: { $exists: false } },
-      { [field]: "" },
-      { [field]: null }
-    ]
-  }
-};
-export {
-  provider_mongo_default as default
-};
+  filter: ({ field, value }) =>
+    value
+      ? {
+          $and: [
+            { [field]: { $exists: value, $ne: '' } },
+            { [field]: { $ne: null } },
+          ],
+        }
+      : {
+          $or: [
+            { [field]: { $exists: false } },
+            { [field]: '' },
+            { [field]: null },
+          ],
+        },
+}
+export { provider_mongo_default as default }

--- a/packages/example-types/build/provider-mongo/exists.js
+++ b/packages/example-types/build/provider-mongo/exists.js
@@ -1,0 +1,20 @@
+// src/types/exists/provider-mongo.js
+import _ from "lodash/fp.js";
+var provider_mongo_default = {
+  hasValue: ({ value }) => _.isBoolean(value),
+  filter: ({ field, value }) => value ? {
+    $and: [
+      { [field]: { $exists: value, $ne: "" } },
+      { [field]: { $ne: null } }
+    ]
+  } : {
+    $or: [
+      { [field]: { $exists: false } },
+      { [field]: "" },
+      { [field]: null }
+    ]
+  }
+};
+export {
+  provider_mongo_default as default
+};

--- a/packages/example-types/esbuild.js
+++ b/packages/example-types/esbuild.js
@@ -5,7 +5,7 @@ await esbuild.build({
   splitting: true,
   packages: 'external',
   platform: 'neutral',
-  outdir: 'dist',
+  outdir: 'build',
   entryPoints: [
     { in: './src/types/bool/client.js', out: 'client/bool' },
     { in: './src/types/bool/provider-mongo.js', out: 'provider-mongo/bool' },

--- a/packages/example-types/esbuild.js
+++ b/packages/example-types/esbuild.js
@@ -1,0 +1,18 @@
+import * as esbuild from 'esbuild'
+
+await esbuild.build({
+  bundle: true,
+  splitting: true,
+  packages: 'external',
+  platform: 'neutral',
+  outdir: 'dist',
+  entryPoints: [
+    { in: './src/types/bool/client.js', out: 'client/bool' },
+    { in: './src/types/bool/provider-mongo.js', out: 'provider-mongo/bool' },
+    { in: './src/types/exists/client.js', out: 'client/exists' },
+    {
+      in: './src/types/exists/provider-mongo.js',
+      out: 'provider-mongo/exists',
+    },
+  ],
+})

--- a/packages/example-types/package.json
+++ b/packages/example-types/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "contexture-example-types",
+  "version": "0.1.0",
+  "description": "Example types for the contexture packages",
+  "type": "module",
+  "exports": {
+    ".": {
+      "import": "./dist/esm/index.js",
+      "require": "./dist/cjs/index.js"
+    },
+    "./*": {
+      "import": "./dist/esm/*",
+      "require": "./dist/cjs/*"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "prepack": "node ../../scripts/esbuild.js --platform=node"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/smartprocure/contexture.git"
+  },
+  "keywords": [
+    "search",
+    "data-context"
+  ],
+  "author": "Samuel Greene",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/smartprocure/contexture/issues"
+  },
+  "homepage": "https://github.com/smartprocure/contexture/tree/main/packages/example-types",
+  "packageManager": "yarn@3.2.4",
+  "dependencies": {
+    "lodash": "^4.17.21"
+  }
+}

--- a/packages/example-types/src/types/bool/client.js
+++ b/packages/example-types/src/types/bool/client.js
@@ -1,0 +1,12 @@
+import { validateValueExistence } from '../../util/client.js'
+
+export default {
+  validate: validateValueExistence,
+  reactors: {
+    value: 'others',
+  },
+  defaults: {
+    field: null,
+    value: null,
+  },
+}

--- a/packages/example-types/src/types/bool/provider-mongo.js
+++ b/packages/example-types/src/types/bool/provider-mongo.js
@@ -1,0 +1,8 @@
+import _ from 'lodash/fp.js'
+
+export default {
+  hasValue: ({ value }) => _.isBoolean(value),
+  filter: ({ field, value }) => ({
+    [field]: value || { $ne: true },
+  }),
+}

--- a/packages/example-types/src/types/bool/provider-mongo.test.js
+++ b/packages/example-types/src/types/bool/provider-mongo.test.js
@@ -1,0 +1,49 @@
+import bool from './provider-mongo.js'
+
+let node = {
+  type: 'bool',
+  field: 'test',
+}
+
+describe('bool', () => {
+  describe('bool.hasValue', () => {
+    it('Should detect a boolean value, null or undefined only', () => {
+      expect(bool.hasValue({ ...node, value: true })).toBe(true)
+      expect(bool.hasValue({ ...node, value: false })).toBe(true)
+      expect(bool.hasValue(node)).toBe(false)
+      expect(bool.hasValue({ ...node, value: null })).toBe(false)
+      expect(bool.hasValue({ ...node, value: undefined })).toBe(false)
+      expect(bool.hasValue({ ...node, value: 0 })).toBe(false)
+      expect(bool.hasValue({ ...node, value: '' })).toBe(false)
+      expect(bool.hasValue({ ...node, value: [] })).toBe(false)
+    })
+  })
+  describe('bool.filter', () => {
+    let neResult = { myField: { $ne: true } }
+    it('Should work', () => {
+      expect(
+        bool.filter({
+          field: 'myField',
+          value: true,
+        })
+      ).toEqual({ myField: true })
+      expect(
+        bool.filter({
+          field: 'myField',
+          value: false,
+        })
+      ).toEqual(neResult)
+      expect(
+        bool.filter({
+          field: 'myField',
+        })
+      ).toEqual(neResult)
+      expect(
+        bool.filter({
+          field: 'myField',
+          value: null,
+        })
+      ).toEqual(neResult)
+    })
+  })
+})

--- a/packages/example-types/src/types/exists/client.js
+++ b/packages/example-types/src/types/exists/client.js
@@ -1,0 +1,12 @@
+import { validateValueExistence } from '../../util/client.js'
+
+export default {
+  validate: validateValueExistence,
+  reactors: {
+    value: 'others',
+  },
+  defaults: {
+    field: null,
+    value: null,
+  },
+}

--- a/packages/example-types/src/types/exists/provider-mongo.js
+++ b/packages/example-types/src/types/exists/provider-mongo.js
@@ -1,0 +1,20 @@
+import _ from 'lodash/fp.js'
+
+export default {
+  hasValue: ({ value }) => _.isBoolean(value),
+  filter: ({ field, value }) =>
+    value
+      ? {
+          $and: [
+            { [field]: { $exists: value, $ne: '' } },
+            { [field]: { $ne: null } },
+          ],
+        }
+      : {
+          $or: [
+            { [field]: { $exists: false } },
+            { [field]: '' },
+            { [field]: null },
+          ],
+        },
+}

--- a/packages/example-types/src/types/exists/provider-mongo.test.js
+++ b/packages/example-types/src/types/exists/provider-mongo.test.js
@@ -1,0 +1,42 @@
+import _ from 'lodash/fp.js'
+import exists from './provider-mongo.js'
+
+let node = {
+  type: 'exists',
+  field: 'test',
+}
+
+describe('exists', () => {
+  describe('exists.hasValue', () => {
+    it('Should detect a boolean value only', () => {
+      expect(exists.hasValue({ ...node, value: true })).toBe(true)
+      expect(exists.hasValue({ ...node, value: false })).toBe(true)
+      expect(exists.hasValue(node)).toBe(false)
+      expect(exists.hasValue({ ...node, value: null })).toBe(false)
+      expect(exists.hasValue({ ...node, value: undefined })).toBe(false)
+    })
+  })
+  describe('exists.filter', () => {
+    it('If a value is provided, use $and', () => {
+      expect(
+        _.get(
+          '$and.0.myField.$exists',
+          exists.filter({
+            value: 'myValue',
+            field: 'myField',
+          })
+        )
+      ).toBe('myValue')
+    })
+    it('If no value is provided, use $or', () => {
+      expect(
+        _.get(
+          '$or.0.myField.$exists',
+          exists.filter({
+            field: 'myField',
+          })
+        )
+      ).toBe(false)
+    })
+  })
+})

--- a/packages/example-types/src/util/client.js
+++ b/packages/example-types/src/util/client.js
@@ -1,0 +1,3 @@
+import _ from 'lodash/fp.js'
+
+export const validateValueExistence = _.flow(_.get('value'), _.negate(_.isNil))

--- a/yarn.lock
+++ b/yarn.lock
@@ -7784,6 +7784,14 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"contexture-example-types@workspace:packages/example-types":
+  version: 0.0.0-use.local
+  resolution: "contexture-example-types@workspace:packages/example-types"
+  dependencies:
+    lodash: ^4.17.21
+  languageName: unknown
+  linkType: soft
+
 "contexture-export@workspace:packages/export":
   version: 0.0.0-use.local
   resolution: "contexture-export@workspace:packages/export"


### PR DESCRIPTION
Proof of concept PR to explore whether it's feasible to move example types into their own package.

Copied types `bool` and `exists` from both the client and the mongo provider to a new package `packages/example-types`. Also tracked the built code under `build` so we can see what's being generated.

I think this could work. We can get nicely encapsulated example types under `src` and also per-package output in `build`. The coolest thing is that shared code gets output into their own chunks so there's no risk of importing the same shared code multiple times.

<img width="349" alt="image" src="https://github.com/smartprocure/contexture/assets/4336260/ba4a084c-bdc7-4f08-8cba-d6ea5bb0da98">