### PR TITLE
Release new contexture-mongo version

### DIFF
--- a/.changeset/funny-islands-complain.md
+++ b/.changeset/funny-islands-complain.md
@@ -1,0 +1,5 @@
+---
+'contexture-mongo': patch
+---
+
+Remove mongodb peer dependency


### PR DESCRIPTION
Forgot to do a patch release in https://github.com/smartprocure/contexture/pull/168. That PR removes a peer dep on mongo in contexture mongo.