### PR TITLE
Make TermsStats work with fieldValuesGroupStats

### DIFF
--- a/.changeset/tidy-apricots-hunt.md
+++ b/.changeset/tidy-apricots-hunt.md
@@ -1,0 +1,5 @@
+---
+'contexture-react': patch
+---
+
+Support fieldValuesGroupStats node type in TermsStatsTable

--- a/packages/react/src/exampleTypes/CheckableTermsStatsTable.js
+++ b/packages/react/src/exampleTypes/CheckableTermsStatsTable.js
@@ -13,7 +13,9 @@ let CheckableTermsStatsTable = ({
   theme: { Checkbox },
   ...props
 }) => {
-  let results = _.result('context.terms.slice', node)
+  let results =
+    _.result('context.terms.slice', node) ??
+    _.result('context.results.slice', node)
   let allChecked = _.size(results) === _.size(F.view(selected))
   let checkAll = F.sets(
     allChecked ? [] : _.map(_.iteratee(getValue), results),

--- a/packages/react/src/exampleTypes/TermsStats.js
+++ b/packages/react/src/exampleTypes/TermsStats.js
@@ -3,7 +3,7 @@ import { contexturify } from '../utils/hoc.js'
 
 let TermsStats = ({ node, theme: { BarChart }, ...props }) => (
   <BarChart
-    data={node.context.terms}
+    data={node.context?.terms ?? node.context?.results}
     categoryField="key"
     valueField={node.order}
     yAxis

--- a/packages/react/src/exampleTypes/TermsStatsTable.js
+++ b/packages/react/src/exampleTypes/TermsStatsTable.js
@@ -80,7 +80,8 @@ let TermsStatsTable = ({
                     <div>
                       <Button
                         onClick={async () => {
-                          let field = criteriaField || node.key_field
+                          let field =
+                            criteriaField || node.key_field || node.groupField
                           let filter =
                             criteria &&
                             _.find({ field }, tree.getNode(criteria).children)
@@ -112,7 +113,7 @@ let TermsStatsTable = ({
             ]
           : _.compact(children),
       }}
-      data={node.context.terms}
+      data={node.context?.terms ?? node.context?.results}
       sortField={node.order}
       sortDir={node.sortDir}
       columnSort={(column) => {


### PR DESCRIPTION
Currently `TermsStatsTable` only works with nodes of type `terms_stats`, however, it's generic enough that it can work with nodes of type `fieldValuesGroupStats`, which is the newer equivalent.