### PR TITLE
When performing scrolling searches make sure to pass scroll_id in the body of the request

### DIFF
--- a/.changeset/long-adults-own.md
+++ b/.changeset/long-adults-own.md
@@ -1,0 +1,5 @@
+---
+'contexture-elasticsearch': patch
+---
+
+When performing scrolling searches make sure to pass scroll_id in the body of the request

--- a/packages/provider-elasticsearch/src/index.js
+++ b/packages/provider-elasticsearch/src/index.js
@@ -51,7 +51,7 @@ let ElasticsearchProvider = (config = { request: {} }) => ({
     let { scroll, scrollId } = node
     let request = scrollId
       ? // If we have scrollId then keep scrolling, no query needed
-        { scroll: scroll === true ? '60m' : hoistedFromFilters, scrollId }
+        { scroll: scroll === true ? '60m' : hoistedFromFilters, body: { scroll_id: scrollId } }
       : // Deterministic ordering of JSON keys for request cache optimization
         {
           index: schema.elasticsearch.index,

--- a/packages/provider-elasticsearch/src/index.js
+++ b/packages/provider-elasticsearch/src/index.js
@@ -51,7 +51,10 @@ let ElasticsearchProvider = (config = { request: {} }) => ({
     let { scroll, scrollId } = node
     let request = scrollId
       ? // If we have scrollId then keep scrolling, no query needed
-        { scroll: scroll === true ? '60m' : hoistedFromFilters, body: { scroll_id: scrollId } }
+        {
+          scroll: scroll === true ? '60m' : hoistedFromFilters,
+          body: { scroll_id: scrollId },
+        }
       : // Deterministic ordering of JSON keys for request cache optimization
         {
           index: schema.elasticsearch.index,


### PR DESCRIPTION
Explained in some detail here

https://github.com/elastic/go-elasticsearch/issues/166

Recommendation from ES documentation

https://www.elastic.co/guide/en/elasticsearch/reference/current/scroll-api.html#scroll-api-path-params