### PR TITLE
[develop] Fix Facet toasts with [object object]

### DIFF
--- a/.changeset/react-facet-title-in-label.md
+++ b/.changeset/react-facet-title-in-label.md
@@ -1,0 +1,5 @@
+---
+'contexture-react': patch
+---
+
+Fix title in Facet component's label should render string and not React node

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "2.58.10",
+  "version": "2.58.11",
   "description": "React components for building contexture interfaces",
   "type": "module",
   "exports": {

--- a/packages/react/src/utils/facet.js
+++ b/packages/react/src/utils/facet.js
@@ -125,8 +125,8 @@ export let FacetCheckboxList = contexturifyWithoutLoader(
       _.partition((x) => _.includes(x.name, node.values)),
       _.flatten,
       F.mapIndexed(({ name, label, count }, i) => {
-        let lens = tree.lens(node.path, 'values');
-        const displayName = display(name, label);
+        let lens = tree.lens(node.path, 'values')
+        const displayName = display(name, label)
         return (
           <label
             // not using unique keys for smart DOM reordering
@@ -135,7 +135,9 @@ export let FacetCheckboxList = contexturifyWithoutLoader(
             key={i}
             style={commonStyle}
             // display() can return a React node, so we need to use the string version
-            title={`${typeof displayName === 'string' ? displayName : name} : ${formatCount(count)}`}
+            title={`${
+              typeof displayName === 'string' ? displayName : name
+            } : ${formatCount(count)}`}
           >
             <Checkbox {...F.domLens.checkboxValues(name, lens)} />
             <div style={{ flex: 2, padding: '0 5px' }}>

--- a/packages/react/src/utils/facet.js
+++ b/packages/react/src/utils/facet.js
@@ -125,7 +125,8 @@ export let FacetCheckboxList = contexturifyWithoutLoader(
       _.partition((x) => _.includes(x.name, node.values)),
       _.flatten,
       F.mapIndexed(({ name, label, count }, i) => {
-        let lens = tree.lens(node.path, 'values')
+        let lens = tree.lens(node.path, 'values');
+        const displayName = display(name, label);
         return (
           <label
             // not using unique keys for smart DOM reordering
@@ -133,11 +134,12 @@ export let FacetCheckboxList = contexturifyWithoutLoader(
             // when clicking something at the bottom of a long list
             key={i}
             style={commonStyle}
-            title={`${display(name, label)} : ${formatCount(count)}`}
+            // display() can return a React node, so we need to use the string version
+            title={`${typeof displayName === 'string' ? displayName : name} : ${formatCount(count)}`}
           >
             <Checkbox {...F.domLens.checkboxValues(name, lens)} />
             <div style={{ flex: 2, padding: '0 5px' }}>
-              {display(name, label) || displayBlank()}
+              {displayName || displayBlank()}
             </div>
             {!hide.counts && <div>{formatCount(count)}</div>}
           </label>


### PR DESCRIPTION
This PR fixes an issue with the toasts showing [object object]. The reason is because the display() callback function can sometimes return a React node instead of a string. This PR fixes it so that it will get the safe string.
