### PR TITLE
Do not set empty highlights on hit if there are none

### DIFF
--- a/.changeset/eleven-bikes-pull.md
+++ b/.changeset/eleven-bikes-pull.md
@@ -1,0 +1,5 @@
+---
+'contexture-elasticsearch': patch
+---
+
+Do not set empty highlights on hit if there are none.

--- a/packages/provider-elasticsearch/src/example-types/results/highlighting/search.js
+++ b/packages/provider-elasticsearch/src/example-types/results/highlighting/search.js
@@ -49,7 +49,9 @@ export let searchWithHighlights = (node, search, schema) => async (body) => {
   )
 
   for (let hit of response.hits.hits) {
-    hit.highlight = getResponseHighlight(schema, hit, tags, nestedPathsMap)
+    if (hit.highlight) {
+      hit.highlight = getResponseHighlight(schema, hit, tags, nestedPathsMap)
+    }
     removePathsFromSource(schema, hit, addedPaths)
     mergeHighlightsOnSource(schema, hit)
   }


### PR DESCRIPTION
A small regression fix: the previous behavior was to not set a `highlight` property on the hit if there were no returned highlights.