### PR TITLE
Add highlightOtherMatches flag to work around performance problems

### DIFF
--- a/.changeset/fuzzy-pigs-smell.md
+++ b/.changeset/fuzzy-pigs-smell.md
@@ -1,0 +1,10 @@
+---
+'contexture-elasticsearch': patch
+'contexture-mongo': patch
+'contexture-client': patch
+'contexture-export': patch
+'contexture': patch
+'contexture-react': patch
+---
+
+Add temporary "highlightOtherMatches" flag (default false) to work around performance problems

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/smartprocure/contexture/tree/main/packages/client",
   "dependencies": {
-    "futil": "^1.76.3",
+    "futil": "^1.76.4",
     "lodash": "^4.17.15"
   },
   "devDependencies": {

--- a/packages/export/package.json
+++ b/packages/export/package.json
@@ -32,7 +32,7 @@
   "homepage": "https://github.com/smartprocure/contexture/tree/main/packages/export",
   "dependencies": {
     "contexture-client": "^2.53.6",
-    "futil": "^1.76.3",
+    "futil": "^1.76.4",
     "lodash": "^4.17.21",
     "minimal-csv-formatter": "^1.0.15"
   },

--- a/packages/provider-elasticsearch/package.json
+++ b/packages/provider-elasticsearch/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "@elastic/datemath": "^2.3.0",
     "debug": "^4.3.1",
-    "futil": "^1.76.3",
+    "futil": "^1.76.4",
     "js-combinatorics": "^2.1.1",
     "lodash": "^4.17.4",
     "minimatch": "^9.0.3",

--- a/packages/provider-elasticsearch/src/example-types/results/highlighting/request.test.js
+++ b/packages/provider-elasticsearch/src/example-types/results/highlighting/request.test.js
@@ -251,7 +251,7 @@ describe('getRequestHighlightFields()', () => {
         'city.street': { elasticsearch: { dataType: 'text' } },
       },
     }
-    let node = {}
+    let node = { highlight: { highlightOtherMatches: true } }
     let actual = getRequestHighlightFields(schema, node)
     expect(actual).toEqual({
       state: {},
@@ -278,7 +278,7 @@ describe('getRequestHighlightFields()', () => {
         },
       },
     }
-    let node = {}
+    let node = { highlight: { highlightOtherMatches: true } }
     let actual = getRequestHighlightFields(schema, node)
     expect(actual).toEqual({
       state: {},
@@ -313,7 +313,7 @@ describe('getRequestHighlightFields()', () => {
         },
       },
     }
-    let node = {}
+    let node = { highlight: { highlightOtherMatches: true } }
     let actual = getRequestHighlightFields(schema, node)
     expect(actual).toEqual({
       state: {},
@@ -341,7 +341,7 @@ describe('getRequestHighlightFields()', () => {
         },
       },
     }
-    let node = {}
+    let node = { highlight: { highlightOtherMatches: true } }
     let actual = getRequestHighlightFields(schema, node)
     expect(actual).toEqual({
       state: {
@@ -389,6 +389,7 @@ describe('getRequestHighlightFields()', () => {
       _meta: {
         relevantFilters: query('address'),
       },
+      highlight: { highlightOtherMatches: true },
     }
     let actual = getRequestHighlightFields(schema, node)
     expect(actual).toEqual({
@@ -450,6 +451,7 @@ describe('getRequestHighlightFields()', () => {
       _meta: {
         relevantFilters: query('address.subfield'),
       },
+      highlight: { highlightOtherMatches: true },
     }
     let actual = getRequestHighlightFields(schema, node)
     expect(actual).toEqual({

--- a/packages/provider-mongo/package.json
+++ b/packages/provider-mongo/package.json
@@ -38,7 +38,7 @@
   "dependencies": {
     "@elastic/datemath": "^2.3.0",
     "debug": "^4.3.1",
-    "futil": "^1.76.3",
+    "futil": "^1.76.4",
     "lodash": "^4.17.4",
     "moment": "^2.18.1",
     "moment-timezone": "^0.5.28"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -80,7 +80,7 @@
   "dependencies": {
     "@chakra-ui/react-use-outside-click": "^2.1.0",
     "contexture": "^0.12.20",
-    "futil": "^1.76.3",
+    "futil": "^1.76.4",
     "lodash": "^4.17.15",
     "moment": "^2.24.0",
     "pluralize": "^8.0.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "@elastic/datemath": "^5.0.3",
     "date-fns": "^2.11.1",
-    "futil": "^1.76.3",
+    "futil": "^1.76.4",
     "lodash": "^4.17.21",
     "moment": "^2.24.0",
     "moment-timezone": "^0.5.28"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7803,7 +7803,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "contexture-client@workspace:packages/client"
   dependencies:
-    futil: ^1.76.3
+    futil: ^1.76.4
     lodash: ^4.17.15
     mobx: ^4.3.1
   languageName: unknown
@@ -7818,7 +7818,7 @@ __metadata:
     agentkeepalive: ^4.1.4
     contexture: ^0.12.20
     debug: ^4.3.1
-    futil: ^1.76.3
+    futil: ^1.76.4
     js-combinatorics: ^2.1.1
     json-stable-stringify: ^1.0.1
     lodash: ^4.17.4
@@ -7834,7 +7834,7 @@ __metadata:
   resolution: "contexture-export@workspace:packages/export"
   dependencies:
     contexture-client: ^2.53.6
-    futil: ^1.76.3
+    futil: ^1.76.4
     lodash: ^4.17.21
     minimal-csv-formatter: ^1.0.15
   languageName: unknown
@@ -7847,7 +7847,7 @@ __metadata:
     "@elastic/datemath": ^2.3.0
     contexture: ^0.12.20
     debug: ^4.3.1
-    futil: ^1.76.3
+    futil: ^1.76.4
     lodash: ^4.17.4
     moment: ^2.18.1
     moment-timezone: ^0.5.28
@@ -7900,7 +7900,7 @@ __metadata:
     emoji-datasource: ^5.0.1
     eslint-plugin-react: ^7.32.0
     eslint-plugin-storybook: ^0.6.14
-    futil: ^1.76.3
+    futil: ^1.76.4
     lodash: ^4.17.15
     material-ui-chip-input: ^1.0.0
     mobx: ^4.3.1
@@ -7936,7 +7936,7 @@ __metadata:
   dependencies:
     "@elastic/datemath": ^5.0.3
     date-fns: ^2.11.1
-    futil: ^1.76.3
+    futil: ^1.76.4
     lodash: ^4.17.21
     mockdate: ^3.0.5
     moment: ^2.24.0
@@ -10121,13 +10121,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"futil@npm:^1.76.3":
-  version: 1.76.3
-  resolution: "futil@npm:1.76.3"
+"futil@npm:^1.76.4":
+  version: 1.76.4
+  resolution: "futil@npm:1.76.4"
   dependencies:
     "@babel/polyfill": ^7.0.0
     lodash: ^4.17.4
-  checksum: 9f881d35d733c9bf0d8e8b32ffa65a96e55ab43871ea23ffed4ed66b7236daea5e5f3046791d94dc3ea79da095a2a2570a5740b73360f8f8d057ae9c85c8e80d
+  checksum: a3d7a05b7c002e27751feae39d464a1b5a5e03efcde7d221e0d670f563d2a8d14dc231ad1603d1bd19b43c15f30c5cdf7ebf291bb706f819a42be5540aa82320
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Not documenting this flag since it's meant to be temporary until we have a better strategy for highlighting additional fields (other matches). The flag's off by default so only fields in the results node `include` are highlighted.