### PR TITLE
Fix error when there are no results node includes

### DIFF
--- a/.changeset/khaki-windows-grow.md
+++ b/.changeset/khaki-windows-grow.md
@@ -1,0 +1,5 @@
+---
+'contexture-elasticsearch': patch
+---
+
+Fix error when there are no results node includes

--- a/packages/provider-elasticsearch/src/example-types/results/highlighting/request.js
+++ b/packages/provider-elasticsearch/src/example-types/results/highlighting/request.js
@@ -190,7 +190,7 @@ export let getRequestHighlightFields = (schema, node) => {
   // TODO: `highlightOtherMatches` is an undocumented configuration value that we
   // are currently using to work around performance issues when highlighting
   // fields not included in the node.
-  if (!node.highlight?.highlightOtherMatches) {
+  if (!node.highlight?.highlightOtherMatches && _.isArray(node.include)) {
     let subFields = getSchemaSubFields({
       fields: _.pick(node.include, schema.fields),
     })


### PR DESCRIPTION
A results' node `include` property may be empty, which means include everything.