### PR TITLE
Allow dots in keywords when searching on exact words

### DIFF
--- a/.changeset/soft-coins-change.md
+++ b/.changeset/soft-coins-change.md
@@ -1,0 +1,7 @@
+---
+'contexture-react': patch
+---
+
+Allow dots in keywords tags
+
+It is very common for users to search for keywords with dots in them when matching on exact words

--- a/packages/react/src/exampleTypes/ExpandableTagsQuery/index.js
+++ b/packages/react/src/exampleTypes/ExpandableTagsQuery/index.js
@@ -18,6 +18,10 @@ import ActionsMenu from '../TagsQuery/ActionsMenu.js'
 import { useOutsideClick } from '@chakra-ui/react-use-outside-click'
 import { sanitizeTagInputs } from 'contexture-elasticsearch/utils/keywordGenerations.js'
 import KeywordGenerations from './KeywordGenerations.js'
+import {
+  alphaNumericRegEx,
+  alphaNumericRegExWithDots,
+} from '../../greyVest/utils.js'
 
 let innerHeightLimit = 40
 
@@ -132,7 +136,11 @@ let TagsWrapper = observer(
     popoverOffsetY,
     theme: { Icon, TagsInput, Tag, Popover },
     joinOptions,
-    wordsMatchPattern,
+    // Allow tag keywords to contain dots in them if user is searching for exact
+    // words instead of their variations.
+    wordsMatchPattern = node.exact
+      ? alphaNumericRegExWithDots
+      : alphaNumericRegEx,
     sanitizeTags = true,
     splitCommas = true,
     maxTags = 1000,

--- a/packages/react/src/exampleTypes/ExpandableTagsQuery/index.js
+++ b/packages/react/src/exampleTypes/ExpandableTagsQuery/index.js
@@ -136,7 +136,7 @@ let TagsWrapper = observer(
     popoverOffsetY,
     theme: { Icon, TagsInput, Tag, Popover },
     joinOptions,
-    // Allow tag keywords to contain dots in them if user is searching for exact
+    // Allow tag keywords to contain dots in them if the user is searching for exact
     // words instead of their variations.
     wordsMatchPattern = node.exact
       ? alphaNumericRegExWithDots

--- a/packages/react/src/exampleTypes/ExpandableTagsQuery/index.js
+++ b/packages/react/src/exampleTypes/ExpandableTagsQuery/index.js
@@ -18,10 +18,7 @@ import ActionsMenu from '../TagsQuery/ActionsMenu.js'
 import { useOutsideClick } from '@chakra-ui/react-use-outside-click'
 import { sanitizeTagInputs } from 'contexture-elasticsearch/utils/keywordGenerations.js'
 import KeywordGenerations from './KeywordGenerations.js'
-import {
-  alphaNumericRegEx,
-  alphaNumericRegExWithDots,
-} from '../../greyVest/utils.js'
+import { wordRegex, wordRegexWithDot } from '../../greyVest/utils.js'
 
 let innerHeightLimit = 40
 
@@ -138,9 +135,7 @@ let TagsWrapper = observer(
     joinOptions,
     // Allow tag keywords to contain dots in them if user is searching for exact
     // words instead of their variations.
-    wordsMatchPattern = node.exact
-      ? alphaNumericRegExWithDots
-      : alphaNumericRegEx,
+    wordsMatchPattern = node.exact ? wordRegexWithDot : wordRegex,
     sanitizeTags = true,
     splitCommas = true,
     maxTags = 1000,

--- a/packages/react/src/greyVest/ExpandableTagsInput.js
+++ b/packages/react/src/greyVest/ExpandableTagsInput.js
@@ -2,11 +2,7 @@ import React from 'react'
 import _ from 'lodash/fp.js'
 import { observer } from 'mobx-react'
 import { Tag as DefaultTag, Flex } from './index.js'
-import {
-  sanitizeTagWords,
-  splitTagOnComma,
-  alphaNumericRegEx,
-} from './utils.js'
+import { sanitizeTagWords, splitTagOnComma, wordRegex } from './utils.js'
 
 export let Tags = ({
   reverse = false,
@@ -54,7 +50,7 @@ let ExpandableTagsInput = ({
   onInputChange = _.noop,
   maxWordsPerTag = 100,
   maxCharsPerTagWord = 100,
-  wordsMatchPattern = alphaNumericRegEx,
+  wordsMatchPattern = wordRegex,
   onTagClick = _.noop,
   sanitizeTags = true,
   Tag = DefaultTag,

--- a/packages/react/src/greyVest/TagsInput.js
+++ b/packages/react/src/greyVest/TagsInput.js
@@ -4,11 +4,7 @@ import { observable } from '../utils/mobx.js'
 import { observer, inject } from 'mobx-react'
 import Flex from './Flex.js'
 import DefaultTag from './Tag.js'
-import {
-  sanitizeTagWords,
-  splitTagOnComma,
-  alphaNumericRegEx,
-} from './utils.js'
+import { sanitizeTagWords, splitTagOnComma, wordRegex } from './utils.js'
 
 let isValidInput = (tag, tags) => !_.isEmpty(tag) && !_.includes(tag, tags)
 
@@ -28,7 +24,7 @@ let TagsInput = forwardRef(
       onTagClick = _.noop,
       maxWordsPerTag = 100,
       maxCharsPerTagWord = 100,
-      wordsMatchPattern = alphaNumericRegEx,
+      wordsMatchPattern = wordRegex,
       sanitizeTags = true,
       Tag = DefaultTag,
       ...props

--- a/packages/react/src/greyVest/utils.js
+++ b/packages/react/src/greyVest/utils.js
@@ -37,14 +37,5 @@ export let splitTagOnComma = _.flow(
   _.uniq
 )
 
-// RegEx to match words composed of alphanumeric characters.
-// From: https://github.com/lodash/lodash/blob/ddfd9b11a0126db2302cb70ec9973b66baec0975/lodash.js#L166
-// Uses ASCI ranges https://donsnotes.com/tech/charsets/ascii.html with the exception that it allows '-' which is \x2D
-export let alphaNumericRegEx =
-  // eslint-disable-next-line no-control-regex
-  /[^\x00-\x2C\x2E-\x2F\x3a-\x40\x5b-\x60\x7b-\x7f]+/g
-
-// Same as above but allowing dots
-export let alphaNumericRegExWithDots =
-  // eslint-disable-next-line no-control-regex
-  /[^\x00-\x2C\x2F\x3a-\x40\x5b-\x60\x7b-\x7f]+/g
+export let wordRegex = /[-\w]+/g
+export let wordRegexWithDot = /[-.\w]+/g

--- a/packages/react/src/greyVest/utils.js
+++ b/packages/react/src/greyVest/utils.js
@@ -43,3 +43,8 @@ export let splitTagOnComma = _.flow(
 export let alphaNumericRegEx =
   // eslint-disable-next-line no-control-regex
   /[^\x00-\x2C\x2E-\x2F\x3a-\x40\x5b-\x60\x7b-\x7f]+/g
+
+// Same as above but allowing dots
+export let alphaNumericRegExWithDots =
+  // eslint-disable-next-line no-control-regex
+  /[^\x00-\x2C\x2F\x3a-\x40\x5b-\x60\x7b-\x7f]+/g


### PR DESCRIPTION
Allow dots in keywords tags when matching on exact words


https://github.com/smartprocure/contexture/assets/4336260/c44b7dc6-453a-4d60-9b6d-781f068906ec

