### PR TITLE
Hide individual filters scrollbar

### DIFF
--- a/.changeset/popular-sheep-compare.md
+++ b/.changeset/popular-sheep-compare.md
@@ -1,0 +1,5 @@
+---
+'contexture-react': patch
+---
+
+Hide scrollbars from individual filters

--- a/packages/react/src/greyVest/Style.js
+++ b/packages/react/src/greyVest/Style.js
@@ -106,6 +106,13 @@ export default () => (
         overflow-y: auto;
         max-height: 80vh;
         transition: max-height .3s ease-in;
+        /* Gecko-based browsers */
+        scrollbar-width: none;
+      }
+
+      /* WebKit-based browsers */
+      .gv-expandable-body.expanded::-webkit-scrollbar {
+        display: none;
       }
 
       /* Table */


### PR DESCRIPTION
## Summary
Our contexture-react components have outdated layouts with negative
margins and other brittle things which causes filters to overflow
horizontally when scroll bars are shown. This PR hides them to prevent
this from happening.
