### PR TITLE
TagsInput: ignore whitespace-only tags

### DIFF
--- a/.changeset/eight-adults-travel.md
+++ b/.changeset/eight-adults-travel.md
@@ -1,0 +1,5 @@
+---
+'contexture-react': patch
+---
+
+TagsInput: do not add whitespace-only tags

--- a/packages/react/src/greyVest/utils.js
+++ b/packages/react/src/greyVest/utils.js
@@ -54,5 +54,6 @@ export let createTags = ({ input, splitCommas, sanitizeTagFn }) =>
     splitCommas ? splitTagOnComma : _.identity,
     _.castArray,
     sanitizeTagFn ? _.map(sanitizeTagFn) : _.identity,
+    _.map(_.trim),
     _.compact
   )(input)


### PR DESCRIPTION
Fixes an oversight in https://github.com/smartprocure/contexture/pull/205 where non-empty tags with only whitespace are not dropped.