### PR TITLE
Add Label Display Function

### DIFF
--- a/packages/react/src/FilterButtonList.js
+++ b/packages/react/src/FilterButtonList.js
@@ -10,6 +10,7 @@ import styles from './styles/index.js'
 import { newNodeFromField } from './utils/search.js'
 import { unusedOptions } from './FilterAdder.js'
 import { fieldsToOptions } from './utils/fields.js'
+import { displayLabelFn } from './utils/format.js'
 
 let FilterButtonItem = _.flow(
   setDisplayName('FilterButtonItem'),
@@ -43,7 +44,7 @@ let FilterButtonItem = _.flow(
           }}
           theme={{ Button: FilterButton }}
         >
-          {title}
+          {displayLabelFn(title, _.get(node.field, fields), fields)}
         </CheckButton>
         <Modal open={modal}>
           <Flex column className="filter-button-modal">

--- a/packages/react/src/FilterButtonList.js
+++ b/packages/react/src/FilterButtonList.js
@@ -44,7 +44,7 @@ let FilterButtonItem = _.flow(
           }}
           theme={{ Button: FilterButton }}
         >
-          {displayLabelFn(title, _.get(node.field, fields), fields)}
+          {displayLabelFn(title, fields, { field: _.get(node.field, fields) })}
         </CheckButton>
         <Modal open={modal}>
           <Flex column className="filter-button-modal">

--- a/packages/react/src/FilterList.js
+++ b/packages/react/src/FilterList.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import _ from 'lodash/fp.js'
 import F from 'futil'
+import { displayLabelFn } from './utils/format.js'
 import { setDisplayName } from 'react-recompose'
 import { observer } from 'mobx-react'
 import { Expandable, Flex, Dynamic } from './greyVest/index.js'
@@ -106,6 +107,7 @@ export let Label = _.flow(
   let popover = React.useState(false)
   let modal = React.useState(false)
   let field = _.get('field', node)
+  let labelText = children || _.get([field, 'label'], fields) || field || ''
   return (
     <Flex
       className={`filter-field-label ${
@@ -118,7 +120,7 @@ export let Label = _.flow(
       }}
     >
       <span {...props}>
-        {children || _.get([field, 'label'], fields) || field || ''}
+        {displayLabelFn(labelText, _.get(field, fields), fields)}
       </span>
       {tree && node && (
         <>

--- a/packages/react/src/FilterList.js
+++ b/packages/react/src/FilterList.js
@@ -120,7 +120,7 @@ export let Label = _.flow(
       }}
     >
       <span {...props}>
-        {displayLabelFn(labelText, _.get(field, fields), fields)}
+        {displayLabelFn(labelText, fields, { field: _.get(field, fields) })}
       </span>
       {tree && node && (
         <>

--- a/packages/react/src/greyVest/NestedPicker.js
+++ b/packages/react/src/greyVest/NestedPicker.js
@@ -72,8 +72,8 @@ let FilteredSection = _.flow(
             >
               {displayLabelFn(
                 <TextHighlight text={option.label} pattern={highlight} />,
-                option,
-                options
+                options,
+                { field: option, isPicker: true }
               )}
             </PickerItem>
           ),
@@ -115,7 +115,10 @@ let Section = _.flow(
                 setHoverItem(isHover ? item : null)
               )}
             >
-              {displayLabelFn(getItemLabel(item), item, options)}
+              {displayLabelFn(getItemLabel(item), options, {
+                field: item,
+                isPicker: true,
+              })}
             </PickerItem>
           ),
           _.flow(F.unkeyBy('_key'), _.sortBy(getItemLabel))(options)

--- a/packages/react/src/greyVest/NestedPicker.js
+++ b/packages/react/src/greyVest/NestedPicker.js
@@ -10,6 +10,7 @@ import Flex from './Flex.js'
 import GVTextInput from './TextInput.js'
 import GVTextHighlight from './TextHighlight.js'
 import { isField } from '../utils/fields.js'
+import { displayLabelFn } from '../utils/format.js'
 
 let PickerContext = React.createContext()
 
@@ -69,7 +70,11 @@ let FilteredSection = _.flow(
                 setHoverItem(isHover ? option : null)
               )}
             >
-              <TextHighlight text={option.label} pattern={highlight} />
+              {displayLabelFn(
+                <TextHighlight text={option.label} pattern={highlight} />,
+                option,
+                options
+              )}
             </PickerItem>
           ),
           options
@@ -110,7 +115,7 @@ let Section = _.flow(
                 setHoverItem(isHover ? item : null)
               )}
             >
-              {getItemLabel(item)}
+              {displayLabelFn(getItemLabel(item), item, options)}
             </PickerItem>
           ),
           _.flow(F.unkeyBy('_key'), _.sortBy(getItemLabel))(options)

--- a/packages/react/src/queryBuilder/FilterContents.js
+++ b/packages/react/src/queryBuilder/FilterContents.js
@@ -13,6 +13,7 @@ import {
   getTypeLabelOptions,
 } from '../utils/search.js'
 import { withTheme } from '../utils/theme.js'
+import { displayLabelFn } from '../utils/format.js'
 
 let FilterContents = ({
   node,
@@ -33,7 +34,13 @@ let FilterContents = ({
   return (
     <Grid columns="auto auto minmax(0, 1fr)" style={style}>
       <ModalPicker
-        label={nodeField ? nodeLabel : 'Pick a Field'}
+        label={
+          nodeField
+            ? displayLabelFn(nodeLabel, fields, {
+                field: _.get(nodeField, fields),
+              })
+            : 'Pick a Field'
+        }
         options={fieldsToOptions(fields)}
         onChange={(addedFields) => {
           addedFields = _.castArray(addedFields)

--- a/packages/react/src/utils/format.js
+++ b/packages/react/src/utils/format.js
@@ -1,5 +1,4 @@
 import _ from 'lodash/fp.js'
-import F from 'futil'
 import React from 'react'
 
 export let toNumber = (number, ...params) => {

--- a/packages/react/src/utils/format.js
+++ b/packages/react/src/utils/format.js
@@ -9,9 +9,9 @@ export let toNumber = (number, ...params) => {
   return NaN
 }
 
-export let displayLabelFn = (value, field, record = {}) =>
-  _.isFunction(field?.labelDisplay)
-    ? field.labelDisplay(value, field, record)
+export let displayLabelFn = (value, record, props) =>
+  _.isFunction(props?.field?.displayLabel)
+    ? props?.field?.displayLabel(value, record, props)
     : value
 
 export let addBlankRows = (rows, pageSize, key) => {

--- a/packages/react/src/utils/format.js
+++ b/packages/react/src/utils/format.js
@@ -1,4 +1,5 @@
 import _ from 'lodash/fp.js'
+import F from 'futil'
 import React from 'react'
 
 export let toNumber = (number, ...params) => {
@@ -8,6 +9,11 @@ export let toNumber = (number, ...params) => {
   }
   return NaN
 }
+
+export let displayLabelFn = (value, field, record = {}) =>
+  _.isFunction(field?.labelDisplay)
+    ? field.labelDisplay(value, field, record)
+    : value
 
 export let addBlankRows = (rows, pageSize, key) => {
   if (rows.length === 0) return rows


### PR DESCRIPTION
## Summary
Update code to allow for label display functions, to show custom content in the label of a field.

## Usage
Here is an example of how the schema in the parent project could consume this to display a custom label: 
```
displayLabel: (label, record, { isPicker }) => (
      <Flex alignItems="center">
        {!isPicker && <AIBadge mr="1" ml="1" />}
        {label}
      </Flex>
    ),
    
