### PR TITLE
Fix tags query tag count when value contains dot

### DIFF
--- a/.changeset/spotty-tigers-cheat.md
+++ b/.changeset/spotty-tigers-cheat.md
@@ -1,0 +1,5 @@
+---
+'contexture-react': patch
+---
+
+Fix tags query tag count when value contains dot

--- a/packages/react/src/exampleTypes/ExpandableTagsQuery/index.js
+++ b/packages/react/src/exampleTypes/ExpandableTagsQuery/index.js
@@ -142,20 +142,16 @@ let TagsWrapper = observer(
   }) => {
     let TagWithPopover = React.memo(
       observer((props) => {
-        let count = F.cascade(
-          [
-            `context.tags.${props.value}`,
-            `context.keywordGenerations.${props.value}`,
-          ],
-          node,
-          node.forceFilterOnly || node.updating
+        let count =
+          _.get(['context', 'tags', props.value], node) ??
+          _.get(['context', 'keywordGenerations', props.value], node) ??
+          (node.forceFilterOnly || node.updating
             ? undefined
             : F.when(
                 _.isNaN(),
                 undefined,
                 _.get(`context.tags.${props.value}`, node)
-              )
-        )
+              ))
         let tagProps = {
           ...props,
           ...(!_.isNil(count) && {


### PR DESCRIPTION
Fix issue where the expandable tags query component wouldn't get counts for the tags when the tag values contained dots.