### PR TITLE
Correct merging of highlights

### DIFF
--- a/.changeset/small-phones-clap.md
+++ b/.changeset/small-phones-clap.md
@@ -1,0 +1,7 @@
+---
+'contexture-elasticsearch': patch
+---
+
+More correct merging of highlights
+
+Fix issue where highlighting will behave wrongly when the text being highlighted contains substrings that match the highlighting tags.

--- a/packages/provider-elasticsearch/src/example-types/results/highlighting/util.js
+++ b/packages/provider-elasticsearch/src/example-types/results/highlighting/util.js
@@ -53,7 +53,7 @@ export let getNestedPathsMap = (schema, paths) => {
 }
 
 export let stripTags = _.curry((tags, str) =>
-  str.replaceAll(tags.pre, '').replaceAll(tags.post, '')
+  str.replaceAll(getRangesRegexp(tags), '$1')
 )
 
 let getRangesRegexp = _.memoize(

--- a/packages/provider-elasticsearch/src/example-types/results/highlighting/util.test.js
+++ b/packages/provider-elasticsearch/src/example-types/results/highlighting/util.test.js
@@ -42,4 +42,20 @@ describe('mergeHighlights()', () => {
       'The quick brown fox <em>jumps</em> over the lazy <em>dog</em>'
     )
   })
+
+  it('should not strip unclosed pre/post tags', () => {
+    let actual = mergeHighlights(
+      {
+        pre: '<b class="search-highlight">',
+        post: '</b>',
+      },
+      [
+        'Shipping Address:</b><b class="search-highlight">MOBILE</b> DIVING AND SALVAGE <b class="another-class">UNIT 1</b>',
+        'Shipping Address:</b>MOBILE DIVING AND SALVAGE <b class="another-class">UNIT 1</b>',
+      ]
+    )
+    expect(actual).toEqual(
+      'Shipping Address:</b><b class="search-highlight">MOBILE</b> DIVING AND SALVAGE <b class="another-class">UNIT 1</b>'
+    )
+  })
 })


### PR DESCRIPTION
Fix issue where highlighting will behave wrongly when the text being highlighted contains substrings that match the highlighting tags (mostly when the highlighted text contains HTML tags).

Refer to the included test for more context.

Here's what the fix looks like in a highlighted document

| **Before** 	| **After** 	|
|:---:	|:---:	|
| <img width="574" alt="Screenshot 2024-06-04 at 4 37 13 PM" src="https://github.com/smartprocure/contexture/assets/4336260/943a46e7-540d-4e1d-9a18-f5b64feb04cd"> | <img width="480" alt="Screenshot 2024-06-04 at 4 38 53 PM" src="https://github.com/smartprocure/contexture/assets/4336260/fd534035-808e-4676-95dd-52c1f15f6f28"> |
