### PR TITLE
Let original errors bubble up when running searches

### DIFF
--- a/.changeset/nine-donkeys-run.md
+++ b/.changeset/nine-donkeys-run.md
@@ -1,0 +1,6 @@
+---
+'contexture-elasticsearch': patch
+'contexture': patch
+---
+
+Bubble up original errors

--- a/packages/provider-elasticsearch/src/index.js
+++ b/packages/provider-elasticsearch/src/index.js
@@ -93,23 +93,13 @@ let ElasticsearchProvider = (config = { request: {} }) => ({
 
     let metaObj = { request, requestOptions }
 
-    try {
-      // Log Request
-      node._meta.requests.push(metaObj)
-      let count = counter.inc()
-      debug('(%s) Request: %O\nOptions: %O', count, request, requestOptions)
-      let { body } = await search(request, requestOptions)
-      metaObj.response = body
-      debug('(%s) Response: %O', count, body)
-    } catch (e) {
-      console.error({ e })
-      metaObj.response = e
-      node.error = e.meta.body.error
-      throw {
-        message: `${e}`,
-        ...e.meta.body.error,
-      }
-    }
+    // Log Request
+    node._meta.requests.push(metaObj)
+    let count = counter.inc()
+    debug('(%s) Request: %O\nOptions: %O', count, request, requestOptions)
+    let { body } = await search(request, requestOptions)
+    metaObj.response = body
+    debug('(%s) Response: %O', count, body)
 
     return metaObj.response
   },

--- a/packages/server/src/index.js
+++ b/packages/server/src/index.js
@@ -17,46 +17,42 @@ let process = _.curry(async ({ providers, schemas }, group, options = {}) => {
     getProvider,
     processGroup: (g, options) => process({ providers, schemas }, g, options),
   })
-  try {
-    await attachFilters(runTypeFunction)(group)
-    Tree.walk((node) => {
-      // Skip groups
-      if (!Tree.traverse(node))
-        node._meta.relevantFilters = getRelevantFilters(
-          getProvider(node).groupCombinator,
-          node._meta.path,
-          group
-        )
-    })(group)
-    await Tree.walkAsync(async (node) => {
-      let validContext = await runTypeFunction('validContext', node)
-
-      // Reject filterOnly
-      if (node.filterOnly || !validContext) {
-        if (!options.debug) delete node._meta
-        return
-      }
-      let curriedSearch = _.partial(getProvider(node).runSearch, [
-        options,
-        node,
-        getSchema(node.schema),
-        node._meta.relevantFilters,
-      ])
-
-      node.context = await runTypeFunction('result', node, curriedSearch).catch(
-        (error) => {
-          throw F.extendOn(error, { node })
-        }
+  await attachFilters(runTypeFunction)(group)
+  Tree.walk((node) => {
+    // Skip groups
+    if (!Tree.traverse(node))
+      node._meta.relevantFilters = getRelevantFilters(
+        getProvider(node).groupCombinator,
+        node._meta.path,
+        group
       )
-      let path = node._meta.path
-      if (!options.debug) delete node._meta
-      if (options.onResult) options.onResult({ path, node })
-    })(group)
+  })(group)
+  await Tree.walkAsync(async (node) => {
+    let validContext = await runTypeFunction('validContext', node)
 
-    return group
-  } catch (error) {
-    throw error.node ? error : new Error(`Uncaught search exception: ${error}`)
-  }
+    // Reject filterOnly
+    if (node.filterOnly || !validContext) {
+      if (!options.debug) delete node._meta
+      return
+    }
+    let curriedSearch = _.partial(getProvider(node).runSearch, [
+      options,
+      node,
+      getSchema(node.schema),
+      node._meta.relevantFilters,
+    ])
+
+    node.context = await runTypeFunction('result', node, curriedSearch).catch(
+      (error) => {
+        throw F.extendOn(error, { node })
+      }
+    )
+    let path = node._meta.path
+    if (!options.debug) delete node._meta
+    if (options.onResult) options.onResult({ path, node })
+  })(group)
+
+  return group
 })
 
 export default process

--- a/packages/server/src/utils.js
+++ b/packages/server/src/utils.js
@@ -61,13 +61,10 @@ export let runTypeFunction = (config) => async (name, node, search) => {
       ? fn(node, search, schema, config)
       : fn(node, schema, config))
   } catch (error) {
-    throw {
-      message: `Failed running search for ${node.type} (${
-        node.key
-      }) at ${name}: ${_.getOr(error, 'message', error)}`,
-      error,
-      node,
-    }
+    // Sometimes we throw strings instead of errors
+    const message = _.getOr(error, 'message', error)
+    error.message = `(at contexture node with key=${node.key} and type=${node.type}) ${message}`
+    throw error
   }
 }
 


### PR DESCRIPTION
It is hard to detect the underlying error that is thrown due to a running searches because we catch them and format them in a few places. This PR removes lets the original errors bubble up, only adding a bit of context to the error message to make it easier to debug where exactly the error happened.