### PR TITLE
Add Partial Results Logging and Request Options

### DIFF
--- a/.changeset/beige-ties-drive.md
+++ b/.changeset/beige-ties-drive.md
@@ -1,0 +1,5 @@
+---
+'contexture-elasticsearch': minor
+---
+
+Enable control of Elastic partial results config and ability to log partial results

--- a/packages/provider-elasticsearch/src/index.js
+++ b/packages/provider-elasticsearch/src/index.js
@@ -110,7 +110,7 @@ let ElasticsearchProvider = (config = { request: {} }) => ({
     // https://www.elastic.co/guide/en/elasticsearch/guide/current/_search_options.html#_timeout_2
     if (body?.timed_out)
       logger &&
-        logger.warn(
+        logger(
           `Returned partial search results, took ${body.took}ms
              Timeout Threshold: ${
                configOptions.timeout ||

--- a/packages/provider-elasticsearch/src/index.js
+++ b/packages/provider-elasticsearch/src/index.js
@@ -108,7 +108,7 @@ let ElasticsearchProvider = (config = { request: {} }) => ({
     // If body has timed_out set to true, log that partial results were returned,
     // if partial is turned off an error will be thrown instead.
     // https://www.elastic.co/guide/en/elasticsearch/guide/current/_search_options.html#_timeout_2
-    if (body.timed_out)
+    if (body?.timed_out)
       logger &&
         logger.warn(
           `Returned partial search results, took ${body.took}ms


### PR DESCRIPTION
## Summary
Add the ability to consume passed in parameters to control partial results and the timeout associated to those results. This PR also enables logging if a custom logger is provided. 
