### PR TITLE
Bump contexture-util

### DIFF
--- a/.changeset/light-eggs-train.md
+++ b/.changeset/light-eggs-train.md
@@ -1,0 +1,5 @@
+---
+'contexture-util': patch
+---
+
+Add date utilities


### PR DESCRIPTION
This package should've been bumped with https://github.com/smartprocure/contexture/pull/224.