### PR TITLE
Change contexture-util version ranges

### DIFF
--- a/packages/provider-elasticsearch/package.json
+++ b/packages/provider-elasticsearch/package.json
@@ -35,7 +35,7 @@
   },
   "homepage": "https://github.com/smartprocure/contexture/tree/main/packages/provider-elasticsearch",
   "dependencies": {
-    "contexture-util": "^0.1.1",
+    "contexture-util": "^0.1.2",
     "debug": "^4.3.1",
     "escape-string-regexp": "^5.0.0",
     "futil": "^1.76.4",

--- a/packages/provider-mongo/package.json
+++ b/packages/provider-mongo/package.json
@@ -36,7 +36,7 @@
   "homepage": "https://github.com/smartprocure/contexture/tree/main/packages/provider-mongo",
   "packageManager": "yarn@3.3.1",
   "dependencies": {
-    "contexture-util": "0.1.2",
+    "contexture-util": "^0.1.2",
     "debug": "^4.3.1",
     "futil": "^1.76.4",
     "lodash": "^4.17.4",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -79,7 +79,7 @@
   "dependencies": {
     "@chakra-ui/react-use-outside-click": "^2.1.0",
     "contexture": "^0.12.23",
-    "contexture-util": "0.1.2",
+    "contexture-util": "^0.1.2",
     "escape-string-regexp": "^5.0.0",
     "futil": "^1.76.4",
     "lodash": "^4.17.15",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -35,7 +35,7 @@
   },
   "homepage": "https://github.com/smartprocure/contexture/tree/main/packages/server",
   "dependencies": {
-    "contexture-util": "0.1.2",
+    "contexture-util": "^0.1.2",
     "date-fns": "^2.11.1",
     "futil": "^1.76.4",
     "lodash": "^4.17.21",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7891,7 +7891,7 @@ __metadata:
     "@elastic/elasticsearch": ^7.11.0
     agentkeepalive: ^4.1.4
     contexture: ^0.12.22
-    contexture-util: ^0.1.1
+    contexture-util: ^0.1.2
     debug: ^4.3.1
     escape-string-regexp: ^5.0.0
     futil: ^1.76.4
@@ -7922,7 +7922,7 @@ __metadata:
   resolution: "contexture-mongo@workspace:packages/provider-mongo"
   dependencies:
     contexture: ^0.12.23
-    contexture-util: 0.1.2
+    contexture-util: ^0.1.2
     debug: ^4.3.1
     futil: ^1.76.4
     lodash: ^4.17.4
@@ -7973,7 +7973,7 @@ __metadata:
     contexture: ^0.12.23
     contexture-client: ^2.53.7
     contexture-elasticsearch: ^1.27.5
-    contexture-util: 0.1.2
+    contexture-util: ^0.1.2
     elasticsearch-browser: ^14.2.2
     emoji-datasource: ^5.0.1
     escape-string-regexp: ^5.0.0
@@ -8009,7 +8009,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"contexture-util@0.1.2, contexture-util@^0.1.1, contexture-util@workspace:packages/util":
+"contexture-util@^0.1.2, contexture-util@workspace:packages/util":
   version: 0.0.0-use.local
   resolution: "contexture-util@workspace:packages/util"
   dependencies:
@@ -8021,7 +8021,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "contexture@workspace:packages/server"
   dependencies:
-    contexture-util: 0.1.2
+    contexture-util: ^0.1.2
     date-fns: ^2.11.1
     futil: ^1.76.4
     lodash: ^4.17.21


### PR DESCRIPTION
For some reason contexture-elasticsearch's version did not get bumped in https://github.com/smartprocure/contexture/pull/227. Also change `contexture-util` version ranges to match that of other monorepo packages with the caret (`^`).