### PR TITLE
Bump contexture-util in contexture-elasticsearch

### DIFF
--- a/.changeset/quick-rings-reflect.md
+++ b/.changeset/quick-rings-reflect.md
@@ -1,0 +1,5 @@
+---
+'contexture-elasticsearch': patch
+---
+
+Bump contexture-util


### PR DESCRIPTION
Forgot to bump contexture-elasticsearch in https://github.com/smartprocure/contexture/pull/228