### PR TITLE
Remove Config Options for Scrolling

### DIFF
--- a/.changeset/dirty-sheep-provide.md
+++ b/.changeset/dirty-sheep-provide.md
@@ -1,0 +1,5 @@
+---
+'contexture-elasticsearch': patch
+---
+
+Remove bad configuration from scrolling payload

--- a/packages/provider-elasticsearch/src/index.js
+++ b/packages/provider-elasticsearch/src/index.js
@@ -57,7 +57,6 @@ let ElasticsearchProvider = (config = { request: {} }) => ({
     let request = scrollId
       ? // If we have scrollId then keep scrolling, no query needed
         {
-          ...configOptions,
           scroll: scroll === true ? '60m' : hoistedFromFilters,
           body: { scroll_id: scrollId },
         }


### PR DESCRIPTION
## Summary
Config options are not valid for scrolling payload within Elastic Search, this PR removes this configuration from that payload. 