### PR TITLE
[Facet Fix] - Respect Zero Config While Filtering Correctly 

### DIFF
--- a/.changeset/brave-trainers-matter.md
+++ b/.changeset/brave-trainers-matter.md
@@ -1,0 +1,6 @@
+---
+'contexture-elasticsearch': patch
+'contexture-react': patch
+---
+
+Respect include zero node config while filtering properly when filtering is enabled for facets

--- a/packages/provider-elasticsearch/src/example-types/filters/facet.js
+++ b/packages/provider-elasticsearch/src/example-types/filters/facet.js
@@ -36,7 +36,8 @@ export default {
             // Size 0 no longer supported natively by ES: https://github.com/elastic/elasticsearch/issues/18838
             size: size || (size === 0 ? elasticsearchIntegerMax : 10),
             order,
-            ...(node.includeZeroes && { min_doc_count: 0 }),
+            ...(node.includeZeroes &&
+              !node.optionsFilter && { min_doc_count: 0 }),
           },
         },
         facetCardinality: { cardinality: { field } },

--- a/packages/provider-elasticsearch/src/example-types/filters/facet.js
+++ b/packages/provider-elasticsearch/src/example-types/filters/facet.js
@@ -61,15 +61,16 @@ export default {
         name: x.key,
         count: x.doc_count,
       })),
-      cardinality: node.includeZeroes
-        ? _.get(
-            'aggregations.facetCardinality.value',
-            await search({
-              aggs: { facetCardinality: { cardinality: { field } } },
-              query: { match_all: {} },
-            })
-          )
-        : agg.facetCardinality.value,
+      cardinality:
+        node.includeZeroes && !node.optionsFilter
+          ? _.get(
+              'aggregations.facetCardinality.value',
+              await search({
+                aggs: { facetCardinality: { cardinality: { field } } },
+                query: { match_all: {} },
+              })
+            )
+          : agg.facetCardinality.value,
     }
 
     // Get missing counts for values sent up but not included in the results

--- a/packages/react/src/utils/facet.js
+++ b/packages/react/src/utils/facet.js
@@ -23,9 +23,7 @@ export let Cardinality = _.flow(
   observer
 )(({ node, tree }) => {
   let size = node.size || 10
-  let optionsSize = _.size(node.context.options)
-  let count =
-    optionsSize < size ? optionsSize : _.get('context.cardinality', node)
+  let count = _.get('context.cardinality', node)
   if (count) {
     return (
       <Flex
@@ -33,7 +31,8 @@ export let Cardinality = _.flow(
         justifyContent="space-between"
       >
         <div>
-          Showing {toNumber(_.min([size, optionsSize]))} of {toNumber(count)}
+          Showing {toNumber(_.min([size, _.size(node.context.options)]))} of{' '}
+          {toNumber(count)}
         </div>
         {count > size && (
           <div>

--- a/packages/react/src/utils/facet.js
+++ b/packages/react/src/utils/facet.js
@@ -23,7 +23,9 @@ export let Cardinality = _.flow(
   observer
 )(({ node, tree }) => {
   let size = node.size || 10
-  let count = _.get('context.cardinality', node)
+  let optionsSize = _.size(node.context.options)
+  let count =
+    optionsSize < size ? optionsSize : _.get('context.cardinality', node)
   if (count) {
     return (
       <Flex
@@ -31,8 +33,7 @@ export let Cardinality = _.flow(
         justifyContent="space-between"
       >
         <div>
-          Showing {toNumber(_.min([size, _.size(node.context.options)]))} of{' '}
-          {toNumber(count)}
+          Showing {toNumber(_.min([size, optionsSize]))} of {toNumber(count)}
         </div>
         {count > size && (
           <div>


### PR DESCRIPTION
## Summary 
This facet filters had a bug that would show all zero counts in Elastic Provider agg buckets even when we were filtering on the field. The expected behavior instead is to show zero counts always but when filtering only the values with counts that match the filter should be shown. This PR corrects this issue, while insuring that the view more button works correctly. 