### PR TITLE
Support elastic search client v8

### DIFF
--- a/.changeset/sharp-birds-rest.md
+++ b/.changeset/sharp-birds-rest.md
@@ -1,0 +1,5 @@
+---
+'contexture-elasticsearch': minor
+---
+
+Support elasticsearch client v8

--- a/packages/provider-elasticsearch/src/compat.js
+++ b/packages/provider-elasticsearch/src/compat.js
@@ -1,0 +1,7 @@
+// Detect if ElasticSearch client is at least version 8 by detecting whether an
+// `extend` method exists on it.
+//
+// @see https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/8.0/changelog-client.html#_remove_client_extensions_api
+export function isAtLeastVersion8(client) {
+  return !client.extend
+}

--- a/packages/provider-elasticsearch/src/index.test.js
+++ b/packages/provider-elasticsearch/src/index.test.js
@@ -47,7 +47,7 @@ describe('Server Provider', () => {
     let firstSearchCall =
       client.child.mock.results[0].value.search.mock.calls[0]
 
-    expect(firstSearchCall[0].body.query.constant_score.filter).toEqual({
+    expect(firstSearchCall[0].query.constant_score.filter).toEqual({
       query_string,
     })
   })
@@ -65,7 +65,7 @@ describe('Server Provider', () => {
     let firstSearchCall =
       client.child.mock.results[0].value.search.mock.calls[0]
 
-    expect(firstSearchCall[0].body).toEqual({ query: undefined })
+    expect(firstSearchCall[0]).toEqual({ query: undefined })
   })
   it('runSearch should not wrap queries in constant_score if sort._score is present', () => {
     const client = {
@@ -87,7 +87,7 @@ describe('Server Provider', () => {
     let firstSearchCall =
       client.child.mock.results[0].value.search.mock.calls[0]
 
-    expect(firstSearchCall[0].body.query).toEqual({
+    expect(firstSearchCall[0].query).toEqual({
       query_string,
     })
   })

--- a/packages/provider-elasticsearch/src/schema.js
+++ b/packages/provider-elasticsearch/src/schema.js
@@ -1,5 +1,6 @@
 import _ from 'lodash/fp.js'
 import F from 'futil'
+import { isAtLeastVersion8 } from './compat.js'
 
 let Tree = F.tree((x) => x.properties)
 // flatLeaves should auto detect reject vs omit (or just more general obj vs arr method)
@@ -83,6 +84,10 @@ export let fromMappingsWithAliases = (mappings, aliases) => {
 
 export let getESSchemas = (client) =>
   Promise.all([client.indices.getMapping(), client.indices.getAlias()]).then(
-    ([{ body: mappings }, { body: aliases }]) =>
-      fromMappingsWithAliases(mappings, aliases)
+    ([mappingResult, aliasResult]) => {
+      return fromMappingsWithAliases(
+        isAtLeastVersion8(client) ? mappingResult : mappingResult.body,
+        isAtLeastVersion8(client) ? aliasResult : aliasResult.body
+      )
+    }
   )

--- a/packages/provider-elasticsearch/src/utils/futil.test.js
+++ b/packages/provider-elasticsearch/src/utils/futil.test.js
@@ -376,7 +376,51 @@ describe('futil candidates', () => {
     it('Should hoist from tree based on demarcation for hoisting from filters', () => {
       let input = {
         index: 'sp-data-lit',
-        body: {
+        query: {
+          constant_score: {
+            filter: {
+              bool: {
+                should: [
+                  {
+                    bool: {
+                      must: [
+                        {
+                          __hoistProps: {
+                            runtime_mappings: {
+                              'FederalDoc.relevantContractDates.signedDate.fiscal':
+                                {
+                                  type: 'date',
+                                  script: {
+                                    source:
+                                      "if(doc['FederalDoc.relevantContractDates.signedDate'].size()!=0){emit(doc['FederalDoc.relevantContractDates.signedDate'].value.plusMonths(params['monthOffset']).toInstant().toEpochMilli())}",
+                                    params: {
+                                      monthOffset: 3,
+                                    },
+                                  },
+                                },
+                            },
+                          },
+                          range: {
+                            'FederalDoc.relevantContractDates.signedDate.fiscal':
+                              {
+                                gte: '2015-04-01T00:00:00.000Z',
+                                lte: '2015-06-30T23:59:59Z',
+                              },
+                          },
+                        },
+                      ],
+                    },
+                  },
+                ],
+                minimum_should_match: 1,
+              },
+            },
+          },
+        },
+      }
+      let output = {
+        result: {
+          index: 'sp-data-lit',
           query: {
             constant_score: {
               filter: {
@@ -386,21 +430,6 @@ describe('futil candidates', () => {
                       bool: {
                         must: [
                           {
-                            __hoistProps: {
-                              runtime_mappings: {
-                                'FederalDoc.relevantContractDates.signedDate.fiscal':
-                                  {
-                                    type: 'date',
-                                    script: {
-                                      source:
-                                        "if(doc['FederalDoc.relevantContractDates.signedDate'].size()!=0){emit(doc['FederalDoc.relevantContractDates.signedDate'].value.plusMonths(params['monthOffset']).toInstant().toEpochMilli())}",
-                                      params: {
-                                        monthOffset: 3,
-                                      },
-                                    },
-                                  },
-                              },
-                            },
                             range: {
                               'FederalDoc.relevantContractDates.signedDate.fiscal':
                                 {
@@ -414,39 +443,6 @@ describe('futil candidates', () => {
                     },
                   ],
                   minimum_should_match: 1,
-                },
-              },
-            },
-          },
-        },
-      }
-      let output = {
-        result: {
-          index: 'sp-data-lit',
-          body: {
-            query: {
-              constant_score: {
-                filter: {
-                  bool: {
-                    should: [
-                      {
-                        bool: {
-                          must: [
-                            {
-                              range: {
-                                'FederalDoc.relevantContractDates.signedDate.fiscal':
-                                  {
-                                    gte: '2015-04-01T00:00:00.000Z',
-                                    lte: '2015-06-30T23:59:59Z',
-                                  },
-                              },
-                            },
-                          ],
-                        },
-                      },
-                    ],
-                    minimum_should_match: 1,
-                  },
                 },
               },
             },


### PR DESCRIPTION
Support [elastic search client v8](https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/8.0/changelog-client.html#_8_0_0).

The only breaking change relevant to the elasticsearch provider is the omission of `body` from both the request and response when executing a search via the client. See [this section](https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/8.0/changelog-client.html#_remove_the_body_key_from_the_request) and [this section](https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/8.0/changelog-client.html#_the_returned_value_of_api_calls_is_the_body_and_not_the_http_related_keys).

**Testing**

Only regression testing is required. Make sure that contexture-elasticsearch still works with both v7 and v8 of the elasticsearch client.