### PR TITLE
Provide more information when throwing errors

### DIFF
--- a/.changeset/quick-mirrors-tease.md
+++ b/.changeset/quick-mirrors-tease.md
@@ -1,0 +1,6 @@
+---
+'contexture-elasticsearch': patch
+'contexture': patch
+---
+
+Better error reporting

--- a/.changeset/quick-mirrors-tease.md
+++ b/.changeset/quick-mirrors-tease.md
@@ -3,4 +3,4 @@
 'contexture': patch
 ---
 
-Better error reporting
+Use the standard Error class [cause property](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause#providing_structured_data_as_the_error_cause) to add more context about the original elasticsearch error.

--- a/packages/server/src/utils.js
+++ b/packages/server/src/utils.js
@@ -60,10 +60,13 @@ export let runTypeFunction = (config) => async (name, node, search) => {
     return await (search
       ? fn(node, search, schema, config)
       : fn(node, schema, config))
-  } catch (error) {
+  } catch (e) {
     // Sometimes we throw strings instead of errors
-    const message = _.getOr(error, 'message', error)
-    error.message = `(at contexture node with key=${node.key} and type=${node.type}) ${message}`
+    const error = _.isString(e) ? new Error(e) : e
+    error.cause = {
+      contexture: { node },
+      ...(_.isString(error.cause) ? { error: error.cause } : error.cause ?? {}),
+    }
     throw error
   }
 }


### PR DESCRIPTION
Use the standard Error class [cause property](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause#providing_structured_data_as_the_error_cause) to add more context about the original elasticsearch error.

<details>
<summary>Before</summary>

```javascript
{
  path: "search"
  method: "create"
  type: "error"
  correlationId: "66ab9da679f959ad29007f5e"
  hook.type: "before"
  message: "(at contexture node with key=undefined and type=fieldValuesGroupStats) x_content_parse_exception: [x_content_parse_exception] Reason: [1:416] [terms] failed to parse field [size]"
  stack: "ResponseError: (at contexture node with key=undefined and type=fieldValuesGroupStats) x_content_parse_exception: [x_content_parse_exception] Reason: [1:416] [terms] failed to parse field [size]\n    at onBody (/Users/ah/Code/smartprocure/spark/node_modules/@elastic/elasticsearch/lib/Transport.js:367:23)\n    at IncomingMessage.onEnd (/Users/ah/Code/smartprocure/spark/node_modules/@elastic/elasticsearch/lib/Transport.js:291:11)\n    at IncomingMessage.emit (node:events:531:35)\n    at endReadableNT (node:internal/streams/readable:1696:12)\n    at process.processTicksAndRejections (node:internal/process/task_queues:82:21)"
}
```

</details>

<details>
<summary>After</summary>

```javascript
{
  path: "search"
  method: "create"
  type: "error"
  correlationId: "66ab9cd459cd7adf705c25ec"
  hook.type: "before"
  message: "x_content_parse_exception: [x_content_parse_exception] Reason: [1:416] [terms] failed to parse field [size]"
  cause: {
    "contexture": {
      "node": {
        "type": "fieldValuesGroupStats",
        "groupField": "Organization.ID",
        "statsField": "LineItem.TotalPrice",
        "size": 0,
        "stats": {
          "sum": true,
          "topHits": {
            "size": 1,
            "_source": [
              "Organization.NameState",
              "Organization.WebSite"
            ]
          }
        },
        "schema": "sp-data-lit"
      }
    },
    "body": {
      "error": {
        "root_cause": [
          {
            "type": "x_content_parse_exception",
            "reason": "[1:416] [terms] failed to parse field [size]"
          }
        ],
        "type": "x_content_parse_exception",
        "reason": "[1:416] [terms] failed to parse field [size]",
        "caused_by": {
          "type": "illegal_argument_exception",
          "reason": "[size] must be greater than 0. Found [0] in [groups]"
        }
      },
      "status": 400
    },
    "statusCode": 400,
    "headers": {
      "content-length": "337",
      "content-type": "application/json",
      "x-cloud-request-id": "r2BGX2psRgmkknQsHE08AQ",
      "x-elastic-product": "Elasticsearch",
      "x-found-handling-cluster": "797f46cce5f64cf7a6ba8ca46dbd154d",
      "x-found-handling-instance": "instance-0000000016",
      "x-opaque-id": "spark-ahernandez@govspend.com",
      "date": "Thu, 01 Aug 2024 14:33:56 GMT"
    }
  }
  stack: "ResponseError: x_content_parse_exception: [x_content_parse_exception] Reason: [1:416] [terms] failed to parse field [size]\n    at onBody (/Users/ah/Code/smartprocure/spark/node_modules/@elastic/elasticsearch/lib/Transport.js:367:23)\n    at IncomingMessage.onEnd (/Users/ah/Code/smartprocure/spark/node_modules/@elastic/elasticsearch/lib/Transport.js:291:11)\n    at IncomingMessage.emit (node:events:531:35)\n    at endReadableNT (node:internal/streams/readable:1696:12)\n    at process.processTicksAndRejections (node:internal/process/task_queues:82:21)"
}
```

</details>
