### PR TITLE
Add new export strategy

### DIFF
--- a/.changeset/shiny-ants-hide.md
+++ b/.changeset/shiny-ants-hide.md
@@ -1,0 +1,5 @@
+---
+'contexture-export': minor
+---
+
+Add a new export strategy for the contexture-elasticsearch fieldValueGroupStats node.

--- a/packages/export/src/nodes/fieldValuesGroupStats.js
+++ b/packages/export/src/nodes/fieldValuesGroupStats.js
@@ -1,0 +1,43 @@
+import { runWith } from '../utils.js'
+
+export async function getTotal(runSearch, { groupField: statsField }) {
+  const node = {
+    type: 'stats',
+    statsField,
+    stats: { cardinality: true },
+  }
+  return (await runSearch(node)).context?.cardinality ?? 0
+}
+
+export async function getResults(
+  runSearch,
+  { groupField, statsField, includeFields }
+) {
+  const node = {
+    type: 'fieldValuesGroupStats',
+    groupField,
+    statsField,
+    size: await getTotal(runSearch, { groupField }),
+    stats: includeFields
+      ? { sum: true, topHits: { size: 1, _source: includeFields } }
+      : { sum: true },
+  }
+  return ((await runSearch(node)).context?.results ?? []).map((result) => ({
+    count: result.count,
+    [groupField]: result.key,
+    sum: result.sum,
+    ...(includeFields ? result.topHits.hits[0]?._source ?? {} : {}),
+  }))
+}
+
+export default (service, tree, props) => {
+  const runSearch = (node) => runWith(service, tree, node)
+  return {
+    getTotalRecords() {
+      return getTotal(runSearch, props)
+    },
+    async *[Symbol.asyncIterator]() {
+      yield* await getResults(runSearch, props)
+    },
+  }
+}

--- a/packages/export/src/nodes/fieldValuesGroupStats.test.js
+++ b/packages/export/src/nodes/fieldValuesGroupStats.test.js
@@ -1,0 +1,116 @@
+import { getResults, getTotal } from './fieldValuesGroupStats.js'
+
+const cardinalityResult = {
+  context: { cardinality: 10 },
+}
+
+const fieldValuesGroupStatsResult = {
+  context: {
+    results: [
+      {
+        sum: 10,
+        count: 20,
+        key: 'John',
+        topHits: {
+          hits: [
+            {
+              _source: {
+                address: '201 John Wick Rd.',
+              },
+            },
+          ],
+        },
+      },
+      {
+        sum: 20,
+        count: 30,
+        key: 'Wick',
+        topHits: {
+          hits: [
+            {
+              _source: {
+                address: '32th Lincoln St.',
+              },
+            },
+          ],
+        },
+      },
+    ],
+  },
+}
+
+describe('getTotal()', () => {
+  it('should return correct cardinality count', async () => {
+    const result = await getTotal(
+      (node) => {
+        expect(node).toEqual({
+          type: 'stats',
+          statsField: 'name',
+          stats: { cardinality: true },
+        })
+        return cardinalityResult
+      },
+      { groupField: 'name' }
+    )
+    expect(result).toEqual(10)
+  })
+})
+
+describe('getResults()', () => {
+  it('should return correct results', async () => {
+    const runSearch = (node) => {
+      if (node.type === 'stats') {
+        return cardinalityResult
+      }
+
+      expect(node).toEqual({
+        type: 'fieldValuesGroupStats',
+        groupField: 'name',
+        statsField: 'age',
+        size: 10,
+        stats: { sum: true },
+      })
+
+      return fieldValuesGroupStatsResult
+    }
+
+    const result = await getResults(runSearch, {
+      groupField: 'name',
+      statsField: 'age',
+    })
+
+    expect(result).toEqual([
+      { sum: 10, count: 20, name: 'John' },
+      { sum: 20, count: 30, name: 'Wick' },
+    ])
+  })
+
+  it('should return correct results with included fields', async () => {
+    const runSearch = (node) => {
+      if (node.type === 'stats') {
+        return cardinalityResult
+      }
+
+      expect(node).toEqual({
+        type: 'fieldValuesGroupStats',
+        groupField: 'name',
+        statsField: 'age',
+        size: 10,
+        stats: { sum: true, topHits: { size: 1, _source: ['address'] } },
+      })
+
+      return fieldValuesGroupStatsResult
+    }
+
+    const result = await getResults(runSearch, {
+      groupField: 'name',
+      statsField: 'age',
+      includeFields: ['address'],
+    })
+
+    expect(result).toEqual([
+      { sum: 10, count: 20, name: 'John', address: '201 John Wick Rd.' },
+      { sum: 20, count: 30, name: 'Wick', address: '32th Lincoln St.' },
+    ])
+  })
+})

--- a/packages/export/src/nodes/index.js
+++ b/packages/export/src/nodes/index.js
@@ -1,5 +1,6 @@
 import results from './results.js'
 import terms_stats from './terms_stats.js'
 import pivot from './pivot.js'
+import fieldValuesGroupStats from './fieldValuesGroupStats.js'
 
-export { results, terms_stats, pivot }
+export { results, terms_stats, pivot, fieldValuesGroupStats }


### PR DESCRIPTION
[Jira ticket](https://govspend.atlassian.net/browse/GS-5732)

Add new export strategy for the contexture-elasticsearch `fieldValuesGroupStats` node.

### Context

We would like to include extra fields for each bucket returned by `terms_stats`, however that node type is deprecated so instead of adding features to it, we decided to add the ability to export `fieldValuesGroupStats` nodes.