### PR TITLE
Fix regression in contexture-elasticsearch error handling

### DIFF
--- a/packages/provider-elasticsearch/src/index.js
+++ b/packages/provider-elasticsearch/src/index.js
@@ -116,10 +116,7 @@ let ElasticsearchProvider = (config = { request: {} }) => ({
     } catch (e) {
       // Provide information about the error in the standard `cause` property
       // See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause#providing_structured_data_as_the_error_cause
-      e.cause = e.meta ?? {}
-      delete e.meta
-      // Remove duplicated information.
-      delete e.cause.meta
+      e.cause = _.omit('meta', e.meta) ?? {}
       throw e
     }
 


### PR DESCRIPTION
Fix regression introduced in [a previous PR](https://github.com/smartprocure/contexture/pull/244) where deleting the `meta` property of a [ResponseError](https://github.com/elastic/elasticsearch-js/blob/7.x/lib/errors.js#L88) will cause a bug in [its string representation](https://github.com/elastic/elasticsearch-js/blob/7.x/lib/errors.js#L123).

This fix only applies to elastic clients previous to v8.
