### PR TITLE
[GS-8040] Add open upper bound capability to `step` query

### DIFF
--- a/.changeset/hungry-pigs-love.md
+++ b/.changeset/hungry-pigs-love.md
@@ -1,6 +1,5 @@
 ---
 'contexture-elasticsearch': minor
-'contexture-client': minor
 ---
 
 capbility of dealing with `null` ranges added to `step` query on elastic search provider

--- a/.changeset/hungry-pigs-love.md
+++ b/.changeset/hungry-pigs-love.md
@@ -3,4 +3,4 @@
 'contexture-client': minor
 ---
 
-`openUpperBound` feature added to `step` query on elastic search provider
+capbility of dealing with `null` ranges added to `step` query on elastic search provider

--- a/.changeset/hungry-pigs-love.md
+++ b/.changeset/hungry-pigs-love.md
@@ -1,0 +1,6 @@
+---
+'contexture-elasticsearch': minor
+'contexture-client': minor
+---
+
+`openUpperBound` feature added to `step` query on elastic search provider

--- a/packages/client/src/exampleTypes.js
+++ b/packages/client/src/exampleTypes.js
@@ -196,7 +196,6 @@ export default F.stampKey('type', {
       field: null,
       range: [0, 1000],
       steps: [0, 1000, 5000, 10000, 25000, 50000, 1000000],
-      openUpperBound: false,
       context: {
         recordsCount: 0,
       },

--- a/packages/client/src/exampleTypes.js
+++ b/packages/client/src/exampleTypes.js
@@ -196,6 +196,7 @@ export default F.stampKey('type', {
       field: null,
       range: [0, 1000],
       steps: [0, 1000, 5000, 10000, 25000, 50000, 1000000],
+      openUpperBound: false,
       context: {
         recordsCount: 0,
       },

--- a/packages/provider-elasticsearch/src/example-types/filters/step.js
+++ b/packages/provider-elasticsearch/src/example-types/filters/step.js
@@ -7,39 +7,26 @@ const getMinAndMax = (range) => {
   return { min, max }
 }
 
-const isValueMaxOnSteps = (value, steps) => {
-  const max = steps[steps.length - 1]
-  return value === max
-}
-
-let filter = ({ field, range, steps }) => {
+let filter = ({ field, range }) => {
   const { min, max } = getMinAndMax(range)
-
-  /** In the last step, we do not filter by the upper bound */
-  if (isValueMaxOnSteps(max, steps)) {
-    return {
-      range: { [field]: pickSafeNumbers({ gte: min }) },
-    }
-  }
-
   return {
     range: { [field]: pickSafeNumbers({ gte: min, lte: max }) },
   }
 }
 
-let buildQuery = (field, range, steps) => {
+let buildQuery = (field, range) => {
   return {
     aggs: {
       rangeFilter: {
-        filter: filter({ field, range, steps }),
+        filter: filter({ field, range }),
       },
     },
   }
 }
 
 let result = async (node, search) => {
-  let { field, range, steps } = node
-  const result = await search(buildQuery(field, range, steps))
+  let { field, range } = node
+  const result = await search(buildQuery(field, range))
   const recordsCount = result.aggregations.rangeFilter.doc_count
   return { recordsCount }
 }

--- a/packages/provider-elasticsearch/src/example-types/filters/step.test.js
+++ b/packages/provider-elasticsearch/src/example-types/filters/step.test.js
@@ -21,10 +21,10 @@ describe('step', () => {
     expect(filter(input)).toEqual(expectedValue)
   })
 
-  it('removes upper bound when range is last step', () => {
+  it('removes upper bound when upper bound is null', () => {
     const inputWithNewRange = {
       ...input,
-      range: [0, 1000],
+      range: [0, null],
     }
     let expectedValue = { range: { test: { gte: 0 } } }
     expect(filter(inputWithNewRange)).toEqual(expectedValue)
@@ -38,7 +38,7 @@ describe('step', () => {
         },
       },
     }
-    let output = buildQuery(input.field, input.range, input.steps)
+    let output = buildQuery(input.field, input.range)
     expect(output).toEqual(expectedDSL)
   })
 })


### PR DESCRIPTION
# [GS-8040](https://govspend.atlassian.net/browse/GS-8040)
## Context
In order to have a controlled way to add/remove an extra step with an open upper bound at the Step Slider component, we need to implement that capability on the `step` query as well.

# ⚠️ How to test
In order to have better understanding how to link the changes of this PR to your local spark, please [read the docs](https://www.notion.so/Contexture-4933169365dd48559d794e54bb48b94c).

## TL;DR Version
### On Spark
```
cd ..
cd api/
yalc link contexture-elasticsearch

cd ..
cd common/
yalc link contexture-client
yalc link contexture-elasticsearch
```

### On Contexture
```
cd ..
cd provider-elasticsearch/
yarn prepack && yalc push --force

cd ..
cd client/
yarn prepack && yalc push --force
```
### On WebApp
- Pull https://github.com/smartprocure/spark/pull/17075 to your local
- Add `Population Count` filter to your Spending page.

# Demo

https://github.com/user-attachments/assets/26aeafa3-9c14-45ca-a1b0-c7f93189314e



