### PR TITLE
contexture-elasticsearch: add option to opt-out of merging highlights onto source

### DIFF
--- a/.changeset/five-coins-fly.md
+++ b/.changeset/five-coins-fly.md
@@ -1,0 +1,5 @@
+---
+'contexture-elasticsearch': minor
+---
+
+Add option to opt-out of merging highlights onto source

--- a/packages/provider-elasticsearch/src/example-types/results/README.md
+++ b/packages/provider-elasticsearch/src/example-types/results/README.md
@@ -152,7 +152,7 @@ In the spirit of keeping our API simple, we generate opinionated highlighting co
 
 ## 2. Response
 
-Currently the only supported behavior is to merge highlighted fragments into `_source` (we may provide an option to opt-out in the future). For this approach to work, fragments must contain the entire field value, so we set [number_of_fragments](https://www.elastic.co/guide/en/elasticsearch/reference/current/highlighting.html#highlighting-settings) to `0` in the request. The exception being blob text fields which set `number_of_fragments` to a number `> 0` since they're too big to highlight in their entirety.
+Currently we set [number_of_fragments](https://www.elastic.co/guide/en/elasticsearch/reference/current/highlighting.html#highlighting-settings) to `0` in the request to include the entire field value in highlighted fragments which makes UI implementations easier. The exception being blob text fields which set `number_of_fragments` to a number `> 0` since they're too big to highlight in their entirety.
 
 Assumming `subfield` to be a sub-field of `details`, the following rules apply when transforming the highlight response:
 

--- a/packages/provider-elasticsearch/src/example-types/results/highlighting/search.js
+++ b/packages/provider-elasticsearch/src/example-types/results/highlighting/search.js
@@ -18,7 +18,8 @@ let tags = {
 
 export let searchWithHighlights = (node, search, schema) => async (body) => {
   // Paths for fields to always include regardless of whether the user included
-  // them. They will be removed from the response hits so there's no harm done.
+  // them. They will be removed from the response hits so the user will not
+  // receive fields they did not request.
   let pathsToAdd = _.flatten(
     F.mapIndexed(
       (paths, arrayPath) => _.map((path) => `${arrayPath}.${path}`, paths),
@@ -53,7 +54,9 @@ export let searchWithHighlights = (node, search, schema) => async (body) => {
       hit.highlight = getResponseHighlight(schema, hit, tags, nestedPathsMap)
     }
     removePathsFromSource(schema, hit, addedPaths)
-    mergeHighlightsOnSource(schema, hit)
+    if (!node.highlight?.disableMergingOnSource) {
+      mergeHighlightsOnSource(schema, hit)
+    }
   }
 
   return response

--- a/packages/provider-elasticsearch/src/example-types/results/type.d.ts
+++ b/packages/provider-elasticsearch/src/example-types/results/type.d.ts
@@ -11,6 +11,11 @@ interface HighlightConfig {
    */
   disable?: boolean
   /**
+   * By default, highlighted fragments are merged into `_source` unless this
+   * flat is set to `true`.
+   */
+  disableMergingOnSource?: boolean
+  /**
    * Paths that should be copied from source into the highlighted results.
    *
    * In the case of arrays of objects, nested paths get copied to every


### PR DESCRIPTION
Currently, highlighted fragments get merged onto field values when requesting results via the `contexture-elasticsearch` `results` query. See [unit tests](https://github.com/smartprocure/contexture/blob/main/packages/provider-elasticsearch/src/example-types/results/highlighting/response.test.js#L444) for examples.

This PR introduces a flag `disableMergingOnSource` to opt-out of this behavior.