### PR TITLE
Fix Highlighting for Field Group Searches in Elastic

### DIFF
--- a/.changeset/strong-terms-hammer.md
+++ b/.changeset/strong-terms-hammer.md
@@ -1,0 +1,5 @@
+---
+'contexture-elasticsearch': patch
+---
+
+Fix highlighting related to multiple matches for separate fields in field group all searches.

--- a/packages/provider-elasticsearch/src/example-types/results/highlighting/request.js
+++ b/packages/provider-elasticsearch/src/example-types/results/highlighting/request.js
@@ -181,7 +181,14 @@ export let getRequestHighlightFields = (schema, node) => {
     )
     if (!_.isEmpty(pathsToReplace)) {
       let regexp = new RegExp(_.join('|', pathsToReplace), 'g')
-      return JSON.parse(_.replace(regexp, path, queryStr))
+      const fieldGroupTransformed = _.replace(regexp, path, queryStr)
+      // Anytime that we have a group field, we need to replace `must` with
+      // `should` to ensure all the searched text is highlighted. This is safe
+      // because the query already returns the correct results and this is just
+      // ensuring that the highlights are correct.
+      // IE. if we search for `foo` and `bar` and the field group contains both
+      // but foo and bar are not in the same field, we want to highlight both still.
+      return JSON.parse(_.replace(/\bmust\b/g, 'should', fieldGroupTransformed))
     }
   }
 

--- a/packages/provider-elasticsearch/src/example-types/results/highlighting/request.test.js
+++ b/packages/provider-elasticsearch/src/example-types/results/highlighting/request.test.js
@@ -380,7 +380,7 @@ describe('getRequestHighlightFields()', () => {
     }
     let query = (field) => ({
       bool: {
-        must: [
+        should: [
           { terms: { [field]: 'memphis' } },
           { query_string: { query: 'memphis', default_field: field } },
         ],
@@ -442,7 +442,7 @@ describe('getRequestHighlightFields()', () => {
     }
     let query = (field) => ({
       bool: {
-        must: [
+        should: [
           { terms: { [field]: 'memphis' } },
           { query_string: { query: 'memphis', default_field: field } },
         ],


### PR DESCRIPTION
## TLDR
Elastic searches that use aggregate fields driven by `copy_to` parameter in the Elastic mappings could be off when providing highlights. This is due to the potential for matches between two fields being considered as an and when in fact for highlighting should be treated as an or. This is due to the potential for multiple matches which in fact originate from two separate fields in the highlight query. This code relies on the safe guard that the query will always provide accurate results, which is what allows us to use an OR for the the highlight queries associated to those results, for accurate highlighting.