### PR TITLE
Fix deprecated `from` field in `range` query

### DIFF
--- a/.changeset/wild-wasps-warn.md
+++ b/.changeset/wild-wasps-warn.md
@@ -1,5 +1,5 @@
 ---
-'contexture-elasticsearch': major
+'contexture-elasticsearch': patch
 ---
 
 Changed deprecated from to gte for range query

--- a/.changeset/wild-wasps-warn.md
+++ b/.changeset/wild-wasps-warn.md
@@ -1,0 +1,5 @@
+---
+'contexture-elasticsearch': major
+---
+
+Changed deprecated from to gte for range query

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -23,7 +23,7 @@ jobs:
           cache: 'yarn'
 
       - name: Install dependencies
-        run: yarn install --immutable
+        run: MONGOMS_DISTRO=rhel-9.0 yarn install --immutable
 
       - name: Lint
         uses: wearerequired/lint-action@v2

--- a/packages/provider-elasticsearch/src/example-types/filters/dateRangeFacet.js
+++ b/packages/provider-elasticsearch/src/example-types/filters/dateRangeFacet.js
@@ -8,8 +8,8 @@ import {
 let getDateRange = (range, timezone) => {
   let { from, to } = rollingRangeToDates(range, timezone)
   return F.compactObject({
-    from: getDateIfValid(from),
-    to: getDateIfValid(to),
+    gte: getDateIfValid(from),
+    lte: getDateIfValid(to),
   })
 }
 

--- a/packages/provider-elasticsearch/src/example-types/filters/dateRangeFacet.test.js
+++ b/packages/provider-elasticsearch/src/example-types/filters/dateRangeFacet.test.js
@@ -58,7 +58,7 @@ describe('dateRangeFacet/filter', () => {
             range: {
               test: {
                 format: 'date_optional_time',
-                from: getDatePart('allFutureDates', 'from'),
+                gte: getDatePart('allFutureDates', 'from'),
               },
             },
           },


### PR DESCRIPTION
Contexture uses `range` for the following example types. The `dateRangeFacet` was using the deprecated `from` syntax.

- steps
- date
- dateRangeFacet
- numberIntervalGroupStats
- dateIntervalGroupStats
- dateRangeGroupStats
- percentilesGroupStats
- numberRangesGroupStats
- number