### PR TITLE
Fix date_range agg

### DIFF
--- a/.changeset/clean-wasps-protect.md
+++ b/.changeset/clean-wasps-protect.md
@@ -1,0 +1,5 @@
+---
+'contexture-elasticsearch': patch
+---
+
+date_range agg uses from/to

--- a/packages/provider-elasticsearch/src/example-types/filters/dateRangeFacet.js
+++ b/packages/provider-elasticsearch/src/example-types/filters/dateRangeFacet.js
@@ -7,13 +7,13 @@ import {
 
 const typeToFields = {
   range: {
-    fromField: "gte",
-    toField: "lte"
+    fromField: 'gte',
+    toField: 'lte',
   },
   date_range: {
-    fromField: "from",
-    toField: "to"
-  }
+    fromField: 'from',
+    toField: 'to',
+  },
 }
 
 let getDateRange = (range, timezone, type) => {

--- a/packages/provider-elasticsearch/src/example-types/filters/dateRangeFacet.test.js
+++ b/packages/provider-elasticsearch/src/example-types/filters/dateRangeFacet.test.js
@@ -3,7 +3,7 @@ import {
   getDateIfValid,
   rollingRangeToDates,
 } from 'contexture-util/dateUtil.js'
-import dateRangeFacet from './dateRangeFacet.js'
+import dateRangeFacet, { genAggsQuery } from './dateRangeFacet.js'
 import { expect, describe, it } from 'vitest'
 
 let commonFilterParts = {
@@ -64,6 +64,62 @@ describe('dateRangeFacet/filter', () => {
           },
         ],
       },
+    })
+  })
+})
+
+describe('genAggsQuery', () => {
+  it('should generate correct aggregation query with default format', () => {
+    const field = 'test_field'
+    const ranges = [
+      { range: 'allFutureDates', key: 'future' },
+      { range: 'allPastDates', key: 'past' },
+    ]
+    const timezone = 'UTC'
+
+    const result = genAggsQuery(field, undefined, ranges, timezone)
+
+    expect(result).toEqual({
+      aggs: {
+        range: {
+          date_range: {
+            field: 'test_field',
+            format: 'date_optional_time',
+            ranges: [
+              {
+                key: 'future',
+                from: getDatePart('allFutureDates', 'from'),
+              },
+              {
+                key: 'past',
+                to: getDatePart('allPastDates', 'to'),
+              },
+            ],
+          },
+        },
+      },
+      size: 0,
+    })
+  })
+
+  it('should handle empty ranges array', () => {
+    const field = 'empty_field'
+    const ranges = []
+    const timezone = 'UTC'
+
+    const result = genAggsQuery(field, undefined, ranges, timezone)
+
+    expect(result).toEqual({
+      aggs: {
+        range: {
+          date_range: {
+            field: 'empty_field',
+            format: 'date_optional_time',
+            ranges: [],
+          },
+        },
+      },
+      size: 0,
     })
   })
 })


### PR DESCRIPTION
The `date_range` agg still requires `from` and `to`.

**date_range**
https://www.elastic.co/docs/reference/aggregations/search-aggregations-bucket-daterange-aggregation

**range**
https://www.elastic.co/docs/reference/query-languages/query-dsl/query-dsl-range-query