### PR TITLE
Accept more parameters in dateIntervalGroupStats query

### DIFF
--- a/.changeset/grumpy-clocks-nail.md
+++ b/.changeset/grumpy-clocks-nail.md
@@ -1,0 +1,5 @@
+---
+'contexture-elasticsearch': minor
+---
+
+Accept more parameters in dateIntervalGroupStats query

--- a/packages/provider-elasticsearch/src/example-types/metricGroups/dateIntervalGroupStats.js
+++ b/packages/provider-elasticsearch/src/example-types/metricGroups/dateIntervalGroupStats.js
@@ -48,7 +48,13 @@ let drilldown = ({ field, interval, drilldown, monthOffset = 3 }) => {
 }
 
 let buildGroupQuery = (node, children, groupsKey) => {
-  let { field, interval = 'year', monthOffset = 3 } = node
+  let {
+    field,
+    interval = 'year',
+    monthOffset = 3,
+    minDocCount = 0,
+    offset,
+  } = node
   let fiscalOrField = fieldFiscalMappingOr(interval)
   interval = toElasticInterval(interval)
 
@@ -72,7 +78,8 @@ let buildGroupQuery = (node, children, groupsKey) => {
           }),
           field: fiscalOrField(field),
           calendar_interval: interval,
-          min_doc_count: 0,
+          min_doc_count: minDocCount,
+          offset,
         },
         ...children,
       },

--- a/packages/provider-elasticsearch/src/example-types/metricGroups/dateIntervalGroupStats.test.js
+++ b/packages/provider-elasticsearch/src/example-types/metricGroups/dateIntervalGroupStats.test.js
@@ -258,4 +258,59 @@ describe('dateIntervalGroupStats', () => {
       },
     })
   })
+  it('should accept offset parameter', () => {
+    expect(
+      buildQuery({
+        key: 'test',
+        type: 'dateIntervalGroupStats',
+        groupField: 'PO.IssuedDate',
+        statsField: 'LineItem.TotalPrice',
+        offset: '+92d',
+      })
+    ).toEqual({
+      aggs: {
+        groups: {
+          date_histogram: {
+            field: 'PO.IssuedDate',
+            calendar_interval: 'year',
+            min_doc_count: 0,
+            offset: '+92d',
+          },
+          aggs: {
+            min: { min: { field: 'LineItem.TotalPrice' } },
+            max: { max: { field: 'LineItem.TotalPrice' } },
+            avg: { avg: { field: 'LineItem.TotalPrice' } },
+            sum: { sum: { field: 'LineItem.TotalPrice' } },
+          },
+        },
+      },
+    })
+  })
+  it('should accept minDocCount parameter', () => {
+    expect(
+      buildQuery({
+        key: 'test',
+        type: 'dateIntervalGroupStats',
+        groupField: 'PO.IssuedDate',
+        statsField: 'LineItem.TotalPrice',
+        minDocCount: 1,
+      })
+    ).toEqual({
+      aggs: {
+        groups: {
+          date_histogram: {
+            field: 'PO.IssuedDate',
+            calendar_interval: 'year',
+            min_doc_count: 1,
+          },
+          aggs: {
+            min: { min: { field: 'LineItem.TotalPrice' } },
+            max: { max: { field: 'LineItem.TotalPrice' } },
+            avg: { avg: { field: 'LineItem.TotalPrice' } },
+            sum: { sum: { field: 'LineItem.TotalPrice' } },
+          },
+        },
+      },
+    })
+  })
 })


### PR DESCRIPTION
Accept `offset` and `min_doc_count` in `dateIntervalGroupStats`

See
- https://www.elastic.co/docs/reference/aggregations/search-aggregations-bucket-datehistogram-aggregation#search-aggregations-bucket-datehistogram-offset
- https://www.elastic.co/docs/reference/aggregations/search-aggregations-bucket-histogram-aggregation#_minimum_document_count