### PR TITLE
Call onUpdateByOthers after results come back

### DIFF
--- a/.changeset/dry-lamps-give.md
+++ b/.changeset/dry-lamps-give.md
@@ -1,0 +1,5 @@
+---
+'contexture-client': minor
+---
+
+Run onUpdateByOthers after search results come back

--- a/packages/client/src/index.js
+++ b/packages/client/src/index.js
@@ -139,9 +139,12 @@ export let ContextTree = _.curry(
           _.map((n) => {
             // When updated by others, force replace instead of merge response
             extend(n, { forceReplaceResponse: true })
-            runTypeFunction(types, 'onUpdateByOthers', n, actionProps)
           }, updatedNodes)
         )
+
+      for (const n of _.remove({ path: snapshot(event.path) }, updatedNodes)) {
+        extend(n, { wasUpdatedByOthers: true })
+      }
 
       // If disableAutoUpdate but this dispatch affects the target node, update *just* that node (to allow things like paging changes to always go through)
       // The assumption here is that any event that affects the target node would likely be assumed to take effect immediately by end users
@@ -229,6 +232,10 @@ export let ContextTree = _.curry(
           else {
             target.forceReplaceResponse = false
             extend(target, responseNode)
+            if (target.wasUpdatedByOthers) {
+              delete target.wasUpdatedByOthers
+              runTypeFunction(types, 'onUpdateByOthers', target, actionProps)
+            }
           }
           if (debug && node._meta) target.metaHistory.push(node._meta)
         }

--- a/packages/client/src/node.js
+++ b/packages/client/src/node.js
@@ -30,6 +30,7 @@ export let internalStateKeys = [
   'onMarkForUpdate',
   'afterSearch',
   'forceReplaceResponse',
+  'wasUpdatedByOthers',
   'expand',
   'collapse',
 ]


### PR DESCRIPTION
We'd like to reset results pagination _after_ results come back, not before.

Additionally, we should also run `onUpdateByOthers` when a field affects both self and others.