### PR TITLE
Call onUpdateByOthers on properties that have an 'all' reactor

### DIFF
--- a/.changeset/wicked-ties-provide.md
+++ b/.changeset/wicked-ties-provide.md
@@ -1,0 +1,5 @@
+---
+'contexture-client': minor
+---
+
+Call onUpdateByOthers on properties that have an 'all' reactor

--- a/packages/client/src/index.js
+++ b/packages/client/src/index.js
@@ -135,11 +135,17 @@ export let ContextTree = _.curry(
         _.find({ path: snapshot(event.path) })
       )(updatedNodes)
       await Promise.all(
-        _.map((n) => {
-          // When updated by others, force replace instead of merge response
-          extend(n, { forceReplaceResponse: true })
-          runTypeFunction(types, 'onUpdateByOthers', n, actionProps)
-        }, _.remove({ path: snapshot(event.path) }, updatedNodes))
+        _.map(
+          (n) => {
+            // When updated by others, force replace instead of merge response
+            extend(n, { forceReplaceResponse: true })
+            runTypeFunction(types, 'onUpdateByOthers', n, actionProps)
+          },
+          _.remove(
+            (n) => _.isEqual(snapshot(n.path), snapshot(event.path)),
+            updatedNodes
+          )
+        )
       )
 
       // If disableAutoUpdate but this dispatch affects the target node, update *just* that node (to allow things like paging changes to always go through)

--- a/packages/client/src/index.js
+++ b/packages/client/src/index.js
@@ -134,14 +134,13 @@ export let ContextTree = _.curry(
         _.map(snapshot),
         _.find({ path: snapshot(event.path) })
       )(updatedNodes)
-      if (!affectsSelf)
-        await Promise.all(
-          _.map((n) => {
-            // When updated by others, force replace instead of merge response
-            extend(n, { forceReplaceResponse: true })
-            runTypeFunction(types, 'onUpdateByOthers', n, actionProps)
-          }, updatedNodes)
-        )
+      await Promise.all(
+        _.map((n) => {
+          // When updated by others, force replace instead of merge response
+          extend(n, { forceReplaceResponse: true })
+          runTypeFunction(types, 'onUpdateByOthers', n, actionProps)
+        }, _.remove({ path: snapshot(event.path) }, updatedNodes))
+      )
 
       // If disableAutoUpdate but this dispatch affects the target node, update *just* that node (to allow things like paging changes to always go through)
       // The assumption here is that any event that affects the target node would likely be assumed to take effect immediately by end users


### PR DESCRIPTION
Fix `onUpdateByOthers` to run also when a type's reactors is set to `all`. Currently only reactors set to `other` cause this function to run.