### PR TITLE
GS-13118 Agencies - After refreshing the page, the newly added column disappears.

### DIFF
--- a/.changeset/hungry-fireants-march.md
+++ b/.changeset/hungry-fireants-march.md
@@ -1,0 +1,5 @@
+---
+'contexture-client': minor
+---
+
+Add tableColumns reactor to results type

--- a/packages/client/src/exampleTypes.js
+++ b/packages/client/src/exampleTypes.js
@@ -150,6 +150,7 @@ export default F.stampKey('type', {
       sortField: 'self',
       sortDir: 'self',
       include: 'self',
+      tableColumns: 'self',
     },
     defaults: {
       page: 1,


### PR DESCRIPTION

### Problem
The `tableColumns` property in the results node was not configured as a reactor, which meant changes to table columns weren't properly triggering updates to maintain the state.

### Solution
Added `tableColumns: 'self'` to the reactors configuration for the `results` example type in `contexture-client`. This ensures that when `tableColumns` is updated, only the node itself is marked for update (not affecting other nodes), allowing the table column configuration to persist correctly.

