### PR TITLE
 Hyperlink Support for Excel Exports

### DIFF
--- a/.changeset/support_clickable_link_in_export.md
+++ b/.changeset/support_clickable_link_in_export.md
@@ -1,0 +1,25 @@
+
+# Release Notes: contexture-export
+
+## [Patch] - Hyperlink Support for Excel Exports
+
+### Overview
+This patch introduces a new feature for Excel-type exports where cells can now be rendered as clickable hyperlinks. This is achieved by providing a specific metadata structure that the exporter converts into native Excel formulas.
+
+### New Features
+* **Dynamic Excel Hyperlinks**: Cells can now display a custom text label while linking to a specific URL.
+* **Metadata-Driven Rendering**: The system identifies links via the `__isHyperlink` flag within the `meta` object.
+* **Display Label Mapping**: The `__alias` property is used as the visible display label for the provided URL.
+* **Formula Safety**: The exporter automatically handles double-quote escaping to ensure the Excel `HYPERLINK` formula remains valid.
+
+### Data Structure Requirements
+To render a cell as a link, the record data for that cell must follow this structure:
+
+```json
+{
+  "url": "[https://example.com/detail/123](https://example.com/detail/123)",
+  "meta": {
+    "__isHyperlink": true,
+    "__alias": "Click to Open Detail Link"
+  }
+}

--- a/.changeset/support_clickable_link_in_export.md
+++ b/.changeset/support_clickable_link_in_export.md
@@ -17,9 +17,9 @@ To render a cell as a link, the record data for that cell must follow this struc
 
 ```json
 {
-  "url": "[https://example.com/detail/123](https://example.com/detail/123)",
+  "url": "https://example.com/detail/123",
   "meta": {
     "__isHyperlink": true,
-    "__alias": "Click to Open Detail Link"
+    "__alias": "Click to Open Link"
   }
 }

--- a/.changeset/support_clickable_link_in_export.md
+++ b/.changeset/support_clickable_link_in_export.md
@@ -1,18 +1,20 @@
-
 # Release Notes: contexture-export
 
 ## [Patch] - Hyperlink Support for Excel Exports
 
 ### Overview
+
 This patch introduces a new feature for Excel-type exports where cells can now be rendered as clickable hyperlinks. This is achieved by providing a specific metadata structure that the exporter converts into native Excel formulas.
 
 ### New Features
-* **Dynamic Excel Hyperlinks**: Cells can now display a custom text label while linking to a specific URL.
-* **Metadata-Driven Rendering**: The system identifies links via the `__isHyperlink` flag within the `meta` object.
-* **Display Label Mapping**: The `__alias` property is used as the visible display label for the provided URL.
-* **Formula Safety**: The exporter automatically handles double-quote escaping to ensure the Excel `HYPERLINK` formula remains valid.
+
+- **Dynamic Excel Hyperlinks**: Cells can now display a custom text label while linking to a specific URL.
+- **Metadata-Driven Rendering**: The system identifies links via the `__isHyperlink` flag within the `meta` object.
+- **Display Label Mapping**: The `__alias` property is used as the visible display label for the provided URL.
+- **Formula Safety**: The exporter automatically handles double-quote escaping to ensure the Excel `HYPERLINK` formula remains valid.
 
 ### Data Structure Requirements
+
 To render a cell as a link, the record data for that cell must follow this structure:
 
 ```json
@@ -23,3 +25,4 @@ To render a cell as a link, the record data for that cell must follow this struc
     "__alias": "Click to Open Link"
   }
 }
+```

--- a/packages/export/package.json
+++ b/packages/export/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-export",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "Contexture Exports",
   "type": "module",
   "exports": {

--- a/packages/export/src/excel.js
+++ b/packages/export/src/excel.js
@@ -9,10 +9,9 @@ let indexColumnBackgroundColor = '#bbbbbb'
 
 const convertToExcelCell = (value, index) => {
   if (value?.meta?.__isHyperlink) {
-    const excelSafeUrl = value?.url?.replace(/"/g, '""') || ''
-    const displayValue = value?.meta?.__alias || excelSafeUrl || ''
+    const displayValue = value?.meta?.__alias || value?.url || 'Link'
     return {
-      value: `HYPERLINK("${excelSafeUrl}", "${displayValue}")`,
+      value: `HYPERLINK("${value?.url}", "${displayValue}")`,
       type: 'Formula',
       wrap: true,
     }

--- a/packages/export/src/excel.js
+++ b/packages/export/src/excel.js
@@ -8,6 +8,15 @@ let headerBackgroundColor = '#999999'
 let indexColumnBackgroundColor = '#bbbbbb'
 
 const convertToExcelCell = (value, index) => {
+  if (value?.meta?.__isHyperlink) {    
+    const excelSafeUrl = value.url.replace(/"/g, '""');
+    const displayValue = value.meta.__alias || excelSafeUrl || '';
+    return {
+      value: `HYPERLINK("${excelSafeUrl}", "${displayValue}")`,
+      type: 'Formula',
+      wrap: true,     
+    };
+  } 
   return {
     wrap: true,
     value: value ? `${value}` : ``,

--- a/packages/export/src/excel.js
+++ b/packages/export/src/excel.js
@@ -8,15 +8,15 @@ let headerBackgroundColor = '#999999'
 let indexColumnBackgroundColor = '#bbbbbb'
 
 const convertToExcelCell = (value, index) => {
-  if (value?.meta?.__isHyperlink) {    
-    const excelSafeUrl = value?.url?.replace(/"/g, '""')||'';
-    const displayValue = value?.meta?.__alias || excelSafeUrl || '';
+  if (value?.meta?.__isHyperlink) {
+    const excelSafeUrl = value?.url?.replace(/"/g, '""') || ''
+    const displayValue = value?.meta?.__alias || excelSafeUrl || ''
     return {
       value: `HYPERLINK("${excelSafeUrl}", "${displayValue}")`,
       type: 'Formula',
-      wrap: true,     
-    };
-  } 
+      wrap: true,
+    }
+  }
   return {
     wrap: true,
     value: value ? `${value}` : ``,

--- a/packages/export/src/excel.js
+++ b/packages/export/src/excel.js
@@ -9,8 +9,8 @@ let indexColumnBackgroundColor = '#bbbbbb'
 
 const convertToExcelCell = (value, index) => {
   if (value?.meta?.__isHyperlink) {    
-    const excelSafeUrl = value.url.replace(/"/g, '""');
-    const displayValue = value.meta.__alias || excelSafeUrl || '';
+    const excelSafeUrl = value?.url?.replace(/"/g, '""')||'';
+    const displayValue = value?.meta?.__alias || excelSafeUrl || '';
     return {
       value: `HYPERLINK("${excelSafeUrl}", "${displayValue}")`,
       type: 'Formula',


### PR DESCRIPTION

# contexture-export

## [Patch] - Hyperlink Support for Excel Exports

### Overview
This patch introduces a new feature for Excel-type exports where cells can now be rendered as clickable hyperlinks. This is achieved by providing a specific metadata structure that the exporter converts into native Excel formulas.

### New Features
* **Dynamic Excel Hyperlinks**: Cells can now display a custom text label while linking to a specific URL.
* **Metadata-Driven Rendering**: The system identifies links via the `__isHyperlink` flag within the `meta` object.
* **Display Label Mapping**: The `__alias` property is used as the visible display label for the provided URL.
* **Formula Safety**: The exporter automatically handles double-quote escaping to ensure the Excel `HYPERLINK` formula remains valid.

### Data Structure Requirements
To render a cell as a link, the record data for that cell must follow this structure:

```json
{
  "url": "https://example.com/detail/123",
  "meta": {
    "__isHyperlink": true,
    "__alias": "Click to Open Link"
  }
}